### PR TITLE
Fix the sprintf bug

### DIFF
--- a/contrib/appsim/LocalStage.c
+++ b/contrib/appsim/LocalStage.c
@@ -13,6 +13,7 @@ int MASLSJobDestroy(mjob_t *);
 int MASLSJobShow(mjob_t *,char *);
 int MASLSJobCreate(mjob_t *,char *);
 int MASLSJobConfig(mjob_t *,char *);
+char temp_str[1024];
 
 
 
@@ -300,20 +301,20 @@ int MASLSJobShow(
 
   if (D->IFileName[0] != '\0')
     {
-    sprintf(Buffer,"%sINPUT:   File: %s:%d over %s\n",
-      Buffer,
+    sprintf(temp_str,"INPUT:   File: %s:%d over %s\n",
       D->IFileName,
       D->IFileSize,
       (D->INetRes != NULL) ? D->INetRes->Name : "DEFAULT");
+    strcat(Buffer,temp_str);
     }
 
   if (D->OFileName[0] != '\0')
     {
-    sprintf(Buffer,"%sOUTPUT:  File: %s:%d over %s\n",
-      Buffer,
+    sprintf(temp_str,"OUTPUT:  File: %s:%d over %s\n",
       D->OFileName,
       D->OFileSize,
       (D->ONetRes != NULL) ? D->ONetRes->Name : "DEFAULT");
+    strcat(Buffer,temp_str);
     }
 
   return(SUCCESS);

--- a/contrib/appsim/Net1.c
+++ b/contrib/appsim/Net1.c
@@ -42,7 +42,7 @@ typedef struct {
   int   AvgTransferDelay;
   } masnet1_t;
 
-
+char temp_str[1024];
 
 const char *MASNet1AttributeType[] = {
   NONE,
@@ -137,29 +137,29 @@ int MASNet1Show(
 
   Buffer[0] = '\0';
 
-  sprintf(Buffer,"%sResource %s  Type:  %s\n\n",
-    Buffer,
+  sprintf(temp_str,"Resource %s  Type:  %s\n\n",
     N->Name,
     "Network");
+  strcat(Buffer,temp_str);
 
-  sprintf(Buffer,"%sState:  %s\n\n",
-    Buffer,
+  sprintf(temp_str,"State:  %s\n\n",
     (N->State == 1) ? "Active" : "Down");
+  strcat(Buffer,temp_str);
 
-  sprintf(Buffer,"%sBandwidth:  %d MB/s\n",
-    Buffer,
+  sprintf(temp_str,"Bandwidth:  %d MB/s\n",
     N->Bandwidth);
+  strcat(Buffer,temp_str);
 
-  sprintf(Buffer,"%sUpTime:  %s    Data Transferred:  %d MB   Transfers Completed: %d\n",
-    Buffer,
+  sprintf(temp_str,"UpTime:  %s    Data Transferred:  %d MB   Transfers Completed: %d\n",
     MULToTString(N->Duration),
     N->MBTransferred,
     N->TransfersCompleted);
+  strcat(Buffer,temp_str);
   
-  sprintf(Buffer,"%sAvg Effective BW/Job: %6.2lf   Avg Delay/Job: %6.2lf\n",
-    Buffer,
+  sprintf(temp_str,"Avg Effective BW/Job: %6.2lf   Avg Delay/Job: %6.2lf\n",
     (N->TransfersCompleted > 0) ? N->AvgTransferBW / N->TransfersCompleted : 0.0,
     (N->TransfersCompleted > 0) ? (double)N->AvgTransferDelay / N->TransfersCompleted : 0.0);
+  strcat(Buffer,temp_str);
 
   strcat(Buffer,"\n");
 
@@ -184,14 +184,14 @@ int MASNet1Show(
       strcpy(tmpString,"N/A");
       }
 
-    sprintf(Buffer,"%s  Transaction[%d]  %s  %d of %d KB   %s -> %s\n",
-      Buffer,
+    sprintf(temp_str,"  Transaction[%d]  %s  %d of %d KB   %s -> %s\n",
       tindex,
       T->FileName,
       T->DataStaged,     
       T->FileSize,
       MULToTString((T->StartTime > 0) ? T->StartTime - MSched.Time : 0),
       tmpString);
+    strcat(Buffer,temp_str);
     }  /* END for tindex) */
 
   strcat(Buffer,"\n");            

--- a/include/moab.h
+++ b/include/moab.h
@@ -1302,6 +1302,8 @@ enum {
   msimfIgnFrame,
   msimfIgnAll };
 
+char temp_str[MMAX_LINE];	      /* Fix the sprintf bug					  */
+
 typedef struct {
   char  WorkloadTraceFile[MAX_MLINE + 1]; /* File Containing Workload Traces  */
   char  ResourceTraceFile[MAX_MLINE + 1]; /* File Containing Resource Traces  */

--- a/src/mcom/MComm.c
+++ b/src/mcom/MComm.c
@@ -147,7 +147,8 @@ int MSUCommWrapMessage(
     msg);
 
   backup = buffer[9];
-  sprintf(buffer, "%08ld\n", (long)strlen(buffer+9));
+  long len = (long)strlen(buffer+9);
+  sprintf(buffer, "%08ld\n", len);
   buffer[9] = backup;
 
   return(strlen(buffer));

--- a/src/mcom/MGrid.c
+++ b/src/mcom/MGrid.c
@@ -563,12 +563,13 @@ int MGlobusJobToRSL(
         sprintf(PreString,"%s://%s",
           MDSProtocol[DS->Protocol],
           (DS->HostName != NULL) ? DS->HostName : "localhost");
-                                                                                
+
+
         if (DS->Port > 0)
           {
-          sprintf(PreString,"%s:%d",
-            PreString,
+          sprintf(temp_str,":%d",
             DS->Port);
+          strcat(PreString,temp_str);
           }
         }
      

--- a/src/mcom/MSU.c
+++ b/src/mcom/MSU.c
@@ -1323,10 +1323,10 @@ int MSUSendData(
 
         if (S->Name[0] != '\0')
           {
-          sprintf(TSLine,"%s %s%s",
-            TSLine,
+          sprintf(temp_str," %s%s",
             MCKeyword[mckClient],
             S->Name);
+          strcat(TSLine,temp_str);
           }
 
         sprintf(TSLine,"%s %s",

--- a/src/mcom/MSec.c
+++ b/src/mcom/MSec.c
@@ -933,9 +933,9 @@ int MSecMD5GetDigest(
 
   for (index = 0;index < MMD5_DIGESTSIZE;index++)
     {
-    sprintf(CSString,"%s%02x",
-      CSString,
+    sprintf(temp_str,"%02x",
       (unsigned char)MD5Sum[index]);
+    strcat(CSString,temp_str);
     }  /* END for (index) */
 
   strcat(CSString,"\n");
@@ -1097,9 +1097,9 @@ int MSecBufToHexEncoding(
 
   for (index = 0;index < IBufLen;index++)
     {
-    sprintf(OBuf,"%s%02x",
-      OBuf,
+    sprintf(temp_str,"%02x",
       (unsigned char)IBuf[index]);
+    strcat(OBuf,temp_str);
     }  /* END for (index) */
 
   return(SUCCESS);

--- a/src/moab/MClass.c
+++ b/src/moab/MClass.c
@@ -473,10 +473,10 @@ int MClassConfigLShow(
       continue;
       }
 
-    sprintf(Buffer,"%s %s=%s",
-      Buffer,
+    sprintf(temp_str," %s=%s",
       MClassAttr[AList[aindex]],
       tmpString);
+    strcat(Buffer,temp_str);
     }  /* END for (aindex) */
 
   return(SUCCESS);
@@ -712,10 +712,10 @@ int MClassConfigShow(
 
       if (tmpVal[0] != '\0')
         {
-        sprintf(tmpLine,"%s %s=%s",
-          tmpLine,
+        sprintf(temp_str," %s=%s",
           MClassAttr[aindex],
           tmpVal);
+        strcat(tmpLine,temp_str);
         }
       }    /* END for (aindex) */
 

--- a/src/moab/MCred.c
+++ b/src/moab/MCred.c
@@ -2182,16 +2182,16 @@ char *__MCredShowLimit(
   if ((P->SLimit[PlIndex][PtIndex] == 0) || 
       (P->SLimit[PlIndex][PtIndex] == P->HLimit[PlIndex][PtIndex]))
     {
-    sprintf(Line,"%s%d",
-      Line,
+    sprintf(temp_str,"%d",
       P->HLimit[PlIndex][PtIndex]);
+    strcat(Line,temp_str);
     }
   else
     {
-    sprintf(Line,"%s%d,%d",
-      Line,
+    sprintf(temp_str,"%d,%d",
       P->SLimit[PlIndex][PtIndex],
       P->HLimit[PlIndex][PtIndex]);
+    strcat(Line,temp_str);
     }
 
   return(Line);
@@ -3268,12 +3268,12 @@ int MCredConfigShow(
 
     MOGetName(O,OIndex,&OName);
 
-    sprintf(Buffer,"%s%s[%s] %s%s\n",
-      Buffer,
+    sprintf(temp_str,"%s[%s] %s%s\n",
       MCredCfgParm[OIndex],
       OName,
       tmpLineC,
       tmpLineS);
+    strcat(Buffer,temp_str);
     }
  
   return(SUCCESS);
@@ -3320,10 +3320,10 @@ int MCredConfigLShow(
       continue;
       }
 
-    sprintf(Buf,"%s %s=%s",
-      Buf,
+    sprintf(temp_str," %s=%s",
       MCredAttr[AList[aindex]],
       tmpString);
+    strcat(Buf,temp_str);
     }  /* END for (aindex) */
 
   return(SUCCESS);

--- a/src/moab/MJob.c
+++ b/src/moab/MJob.c
@@ -4399,9 +4399,9 @@ int MJobReserve(
           J->Name,
           sindex,
           RQ->TaskRequestList[sindex]);
- 
-        sprintf(Message,"%s (intital reservation attempt)\n",
-          Message);
+
+        sprintf(temp_str," (intital reservation attempt)\n");
+        strcat(Message,temp_str);
         }
       }    /* END if (MJobGetEStartTime() == FAILURE) */
     else
@@ -4432,17 +4432,17 @@ int MJobReserve(
         J->Name,
         IStringTime);
  
-      sprintf(Message,"%s (job previously reserved to start in %s)\n",
-        Message,
+      sprintf(temp_str," (job previously reserved to start in %s)\n",
         IStringTime);
+      strcat(Message,temp_str);
       }
     else
       {
       DBG(1,fSCHED) DPrint("ALERT:    cannot create new reservation for job %s\n",
         J->Name); 
  
-      sprintf(Message,"%s (intital reservation attempt)\n",
-        Message);
+      sprintf(temp_str," (intital reservation attempt)\n");
+      strcat(Message,temp_str);
       }
  
     if (MSched.Mode != msmTest)
@@ -12364,10 +12364,10 @@ int MJobToTString(
         {
         if (RQ[0]->DRes.PSlot[cindex].count > 0)
           {
-          sprintf(Classes,"%s[%s:%d]",
-            Classes,
+          sprintf(temp_str,"[%s:%d]",
             MAList[eClass][cindex],
             RQ[0]->DRes.PSlot[cindex].count);
+          strcat(Classes, temp_str);
           }
         }    /* END for (cindex) */
 

--- a/src/moab/MNode.c
+++ b/src/moab/MNode.c
@@ -2649,23 +2649,23 @@ int MNodeShowState(
 
   if (N->MaxLoad > 0.01)
     {
-    sprintf(tmpLine,"%s (MaxLoad: %.2lf)",
-      tmpLine,
+    sprintf(temp_str," (MaxLoad: %.2lf)",
       N->MaxLoad);
+    strcat(tmpLine,temp_str);
     }
 
   if (N->ExtLoad > 0.01)
     {
-    sprintf(tmpLine,"%s (ExtLoad: %.2lf)",
-      tmpLine,
+    sprintf(temp_str," (ExtLoad: %.2lf)",
       N->ExtLoad);
+    strcat(tmpLine,temp_str);
     }
 
   if (N->ProcSpeed > 0)
     {
-    sprintf(tmpLine,"%s (ProcSpeed: %d)",
-      tmpLine,
+    sprintf(temp_str," (ProcSpeed: %d)",
       N->ProcSpeed);
+    strcat(tmpLine,temp_str);
     }
 
   strcat(tmpLine,"\n");
@@ -6262,18 +6262,18 @@ char *MNodePrioFToString(
 
     if (N->P->CW[aindex] == 1.0)
       {
-      sprintf(ptr,"%s%s%s",
-        ptr,
+      sprintf(temp_str,"%s%s",
         ((N->P->CW[aindex] > 0.0) && (ptr[0] != '\0')) ? "+" : "",
         MNPComp[aindex]);
+      strcat(ptr,temp_str);
       }
     else
       {
-      sprintf(ptr,"%s%s%.2lf*%s",
-        ptr,
+      sprintf(temp_str,"%s%.2lf*%s",
         ((N->P->CW[aindex] > 0.0) && (ptr[0] != '\0')) ? "+" : "",
         N->P->CW[aindex],
         MNPComp[aindex]);
+      strcat(ptr,temp_str);
       }
     }    /* END for (aindex) */
   
@@ -6344,11 +6344,11 @@ int MNodeConfigShow(
         continue;
         }
 
-      sprintf(NLine,"%s%s%s=%s",
-        NLine,
+      sprintf(temp_str,"%s%s=%s",
         (NLine[0] != '\0') ? " " : "",
         MNodeAttr[AList[aindex]],
         tmpLine);
+      strcat(NLine, temp_str);
       }    /* END for (aindex) */
 
     if ((VFlag == TRUE) || (NLine[0] != '\0'))

--- a/src/moab/MPBSI.c
+++ b/src/moab/MPBSI.c
@@ -189,9 +189,9 @@ int MPBSInitialize(
 
   if (R->P[0].Port > 0)
     {
-    sprintf(PBSServer,"%s:%d",
-      PBSServer,
+    sprintf(temp_str,":%d",
       R->P[0].Port);
+    strcat(PBSServer,temp_str);
     }
 
   if (InitialAttempt == TRUE)

--- a/src/moab/MPar.c
+++ b/src/moab/MPar.c
@@ -874,15 +874,15 @@ int MParShow(
  
   MUStrCpy(PList,MParBMToString(MPar[0].F.PAL),sizeof(PList));
  
-  sprintf(Buffer,"%sSystem Partition Settings:  PList: %s PDef: %s\n\n",
-    Buffer,
+  sprintf(temp_str,"System Partition Settings:  PList: %s PDef: %s\n\n",
     PList,
     (MPar[0].F.PDef != NULL) ? ((mpar_t  *)MPar[0].F.PDef)->Name : NONE);
+  strcat(Buffer,temp_str);
 
-  sprintf(Buffer,"%s%-20s %8s\n\n",
-    Buffer,
+  sprintf(temp_str,"%-20s %8s\n\n",
     "Name",
     "Procs");
+  strcat(Buffer,temp_str);
  
   for (pindex = 0;pindex < MAX_MPAR;pindex++)
     {
@@ -902,10 +902,10 @@ int MParShow(
  
     Line[0] = '\0';
  
-    sprintf(Buffer,"%s%-20s %8d\n",
-      Buffer,
+    sprintf(temp_str,"%-20s %8d\n",
       (P->Name[0] != '\0') ? P->Name : NONE,
       P->CRes.Procs);
+    strcat(Buffer,temp_str);
  
     /* check user access */
  
@@ -920,18 +920,18 @@ int MParShow(
  
       if (MUBMCheck(pindex,U->F.PAL))
         {
-        sprintf(Line,"%s %s%s",
-          Line,
+        sprintf(temp_str," %s%s",
           U->Name,
           MQALType[U->F.PALType]);
+        strcat(Line,temp_str);
         }
       }  /* END for (index) */ 
  
     if (Line[0] != '\0')
       {
-      sprintf(Buffer,"%s  Users:    %s\n",
-        Buffer,
+      sprintf(temp_str,"  Users:    %s\n",
         Line);
+      strcat(Buffer,temp_str);
       }
  
     /* check group access */
@@ -947,18 +947,18 @@ int MParShow(
  
       if (MUBMCheck(pindex,G->F.PAL))
         {
-        sprintf(Line,"%s %s%s",
-          Line,
+        sprintf(temp_str," %s%s",
           G->Name,
           MQALType[G->F.PALType]);
+        strcat(Line,temp_str);
         }
       }  /* END for (index) */
  
     if (Line[0] != '\0')
       {
-      sprintf(Buffer,"%s  Groups:   %s\n",
-        Buffer,
+      sprintf(temp_str,"  Groups:   %s\n",
         Line);
+      strcat(Buffer,temp_str);
       }
  
     /* check account access */
@@ -974,18 +974,18 @@ int MParShow(
  
       if (MUBMCheck(pindex,A->F.PAL))
         {
-        sprintf(Line,"%s %s%s",
-          Line,
+        sprintf(temp_str," %s%s",
           A->Name,
           MQALType[A->F.PALType]);
+        strcat(Line,temp_str);
         }
       }  /* END for (index) */
  
     if (Line[0] != '\0')
       {
-      sprintf(Buffer,"%s  Accounts: %s\n",
-        Buffer,
+      sprintf(temp_str,"  Accounts: %s\n",
         Line);
+      strcat(Buffer,temp_str);
       }
 
        /* check class access */
@@ -1001,32 +1001,31 @@ int MParShow(
 
       if (MUBMCheck(pindex,C->F.PAL))
         {
-        sprintf(Line,"%s %s%s",
-          Line,
+        sprintf(temp_str," %s%s",
           C->Name,
           MQALType[C->F.PALType]);
+        strcat(Line,temp_str);
         }
       }  /* END for (index) */
 
     if (Line[0] != '\0')
       {
-      sprintf(Buffer,"%s  Classes: %s\n",
-        Buffer,
+      sprintf(temp_str,"  Classes: %s\n",
         Line);
+      strcat(Buffer,temp_str);
       }
 
     if (P->Message != NULL)
       {
-      sprintf(Buffer,"%s  Message: %s\n",
-        Buffer,
+      sprintf(temp_str,"  Message: %s\n",
         P->Message);
+      strcat(Buffer,temp_str);
       }  /* END if (P->Message) */
     }  /* END for (pindex) */
 
   /* show resource state */
 
-  sprintf(Buffer,"%s\n%-12s %10s %10s %7s %10s %7s %10s %7s\n\n",
-    Buffer,
+  sprintf(temp_str,"\n%-12s %10s %10s %7s %10s %7s %10s %7s\n\n",
     "Partition",
     "Configured",
     "Up",
@@ -1035,6 +1034,7 @@ int MParShow(
     "D/U",
     "Active",
     "A/U");
+  strcat(Buffer,temp_str);
 
   for (rindex = mrNode;rindex <= mrDisk;rindex++)
     {
@@ -1125,8 +1125,7 @@ int MParShow(
         strcat(Buffer,"----------------------------------------------------------------------------\n");
         }
 
-      sprintf(Buffer,"%s%-12s %10d %10d %6.2f%c %10d %6.2f%c %10d %6.2f%c\n",
-        Buffer,
+      sprintf(temp_str,"%-12s %10d %10d %6.2f%c %10d %6.2f%c %10d %6.2f%c\n",
         P->Name,
         CRes,
         URes,
@@ -1138,6 +1137,7 @@ int MParShow(
         (URes - ARes),
         (double)((URes > 0) ? (URes - ARes) * 100.0 / URes : 0.0),
         '%');
+      strcat(Buffer,temp_str);
       } /* END for (pindex) */
     }    /* END for (rindex) */
 
@@ -1145,9 +1145,9 @@ int MParShow(
  
   strcat(Buffer,"\nClass/Queue State\n\n");
  
-  sprintf(Buffer,"%s%12s [<CLASS> <AVAIL>:<UP>]...\n\n",
-    Buffer,
+  sprintf(temp_str,"%12s [<CLASS> <AVAIL>:<UP>]...\n\n",
     " ");
+  strcat(Buffer,temp_str);
  
   for (pindex = 0;pindex < MAX_MPAR;pindex++)
     {
@@ -1163,10 +1163,10 @@ int MParShow(
       continue;
       }
  
-    sprintf(Buffer,"%s%12s %s\n",
-      Buffer,
+    sprintf(temp_str,"%12s %s\n",
       P->Name,
       MUCAListToString(P->ARes.PSlot,P->URes.PSlot,NULL));
+    strcat(Buffer,temp_str);
     }   /* END for (pindex) */
  
   return(SUCCESS);
@@ -1263,9 +1263,9 @@ char *MParBMToString(
     if (tmpLine[0] != '\0')
       strcat(tmpLine,":");
 
-    sprintf(tmpLine,"%s%s",
-      tmpLine,
+    sprintf(temp_str,"%s",
       P->Name);
+    strcat(tmpLine,temp_str);
     }  /* END for (pindex) */
  
   return(tmpLine);
@@ -1997,9 +1997,9 @@ int MParConfigShow(
     }
   else
     {
-    sprintf(Buffer,"%s\n# partition %s policies\n\n",
-      Buffer,
+    sprintf(temp_str,"\n# partition %s policies\n\n",
       P->Name);
+    strcat(Buffer,temp_str);
     }
 
   if ((P->RejectNegPrioJobs != DEFAULT_MREJECTNEGPRIOJOBS) ||
@@ -2060,19 +2060,19 @@ int MParConfigShow(
   if ((P->JobPrioAccrualPolicy != jpapNONE) || 
       (VFlag || (PIndex == -1) || (PIndex == pJobPrioAccrualPolicy)))
     {
-    sprintf(Buffer,"%s%-30s  %s\n",
-      Buffer,
+    sprintf(temp_str,"%-30s  %s\n",
       MParam[pJobPrioAccrualPolicy],
       (char *)MJobPrioAccrualPolicyType[P->JobPrioAccrualPolicy]);
+    strcat(Buffer,temp_str);
     }
 
   if ((P->NodeLoadPolicy != nlpNONE) || 
       (VFlag || (PIndex == -1) || (PIndex == pNodeLoadPolicy)))
     {
-    sprintf(Buffer,"%s%-30s  %s\n",
-      Buffer,
+    sprintf(temp_str,"%-30s  %s\n",
       MParam[pNodeLoadPolicy],
       (char *)MNodeLoadPolicyType[P->NodeLoadPolicy]);
+    strcat(Buffer,temp_str);
     }
 
   if (P->Index == 0)
@@ -2080,46 +2080,46 @@ int MParConfigShow(
     if ((P->UseMachineSpeedForFS == TRUE) || 
         (VFlag || (PIndex == -1) || (PIndex == pUseMachineSpeedForFS)))
       {
-      sprintf(Buffer,"%s%-30s  %s\n",
-        Buffer,
+      sprintf(temp_str,"%-30s  %s\n",
         MParam[pUseMachineSpeedForFS],
         (P->UseMachineSpeedForFS == TRUE) ? "TRUE" : "FALSE");
+      strcat(Buffer,temp_str);
       }
 
     if ((P->UseMachineSpeed == TRUE) || 
         (VFlag || (PIndex == -1) || (PIndex == pUseMachineSpeed)))
       {
-      sprintf(Buffer,"%s%-30s  %s\n",
-        Buffer,
+      sprintf(temp_str,"%-30s  %s\n",
         MParam[pUseMachineSpeed],
         (P->UseMachineSpeed == TRUE) ? "TRUE" : "FALSE");
+      strcat(Buffer,temp_str);
       }
 
     if ((P->UseSystemQueueTime == FALSE) || 
         (VFlag || (PIndex == -1) || (PIndex == pUseSystemQueueTime)))
       {
-      sprintf(Buffer,"%s%-30s  %s\n",
-        Buffer,
+      sprintf(temp_str,"%-30s  %s\n",
         MParam[pUseSystemQueueTime],
         (P->UseSystemQueueTime == TRUE) ? "TRUE" : "FALSE");
+      strcat(Buffer,temp_str);
       }
 
     if ((P->UseLocalMachinePriority != TRUE) || 
         (VFlag || (PIndex == -1) || (PIndex == pUseLocalMachinePriority)))
       {
-      sprintf(Buffer,"%s%-30s  %s\n",
-        Buffer,
+      sprintf(temp_str,"%-30s  %s\n",
         MParam[pUseLocalMachinePriority],
         (P->UseLocalMachinePriority == TRUE) ? "TRUE" : "FALSE");
+      strcat(Buffer,temp_str);
       }
 
     if ((P->UntrackedProcFactor > 0.0) || 
         (VFlag || (PIndex == -1) || (PIndex == pNodeUntrackedProcFactor)))
       {
-      sprintf(Buffer,"%s%-30s  %.1lf\n",
-        Buffer,
+      sprintf(temp_str,"%-30s  %.1lf\n",
         MParam[pNodeUntrackedProcFactor],
         P->UntrackedProcFactor);
+      strcat(Buffer,temp_str);
       }
     }    /* END if (P->Index == 0) */
 
@@ -2202,9 +2202,9 @@ int MParConfigShow(
 
     for (index = 0;P->NodeSetList[index] != NULL;index++)
       {
-      sprintf(tmpLine,"%s%s ",
-        tmpLine,
+      sprintf(temp_str,"%s ",
         P->NodeSetList[index]);
+      strcat(tmpLine,temp_str);
       }  /* END for (index) */
 
     strcat(
@@ -2343,20 +2343,20 @@ int MParConfigShow(
           {
           if (P->ResourceLimitMaxViolationTime[index] > 0)
             {
-            sprintf(tmpLine,"%s%s:%s:%s:%s ",
-              tmpLine,
+            sprintf(temp_str,"%s:%s:%s:%s ",
               MResourceType[index],
               MResourceLimitPolicyType[P->ResourceLimitPolicy[index]],
               MPolicyAction[P->ResourceLimitViolationAction[index]],
               MULToTString(P->ResourceLimitMaxViolationTime[index]));
+            strcat(tmpLine,temp_str);
             }
           else
             {
-            sprintf(tmpLine,"%s%s:%s:%s ",
-              tmpLine,
+            sprintf(temp_str,"%s:%s:%s ",
               MResourceType[index],
               MResourceLimitPolicyType[P->ResourceLimitPolicy[index]],
               MPolicyAction[P->ResourceLimitViolationAction[index]]);
+            strcat(tmpLine,temp_str);
             }
           }
         }    /* END for (index) */
@@ -2388,10 +2388,10 @@ int MParConfigShow(
         if (tmpLine[0] != '\0')
           strcat(tmpLine," ");
 
-        sprintf(tmpLine,"%s%s:%s",
-          tmpLine,
+        sprintf(temp_str,"%s:%s",
           MNAvailPolicy[policyindex],
           (rindex == 0) ? DEFAULT : MResourceType[rindex]);
+        strcat(tmpLine,temp_str);
         }  /* END for (rindex) */
 
       strcat(
@@ -2473,15 +2473,15 @@ int MParConfigShow(
             {
             if (P->ResQOSList[index][qindex] == (mqos_t *)MAX_MQOS)
               {
-              sprintf(tmpLine,"%s%s ",
-                tmpLine,
+              sprintf(temp_str,"%s ",
                 ALL);
+              strcat(tmpLine,temp_str);
               }
             else
               {
-              sprintf(tmpLine,"%s%s ",
-                tmpLine,
+              sprintf(temp_str,"%s ",
                 P->ResQOSList[index][qindex]->Name);
+              strcat(tmpLine,temp_str);
               }
             }
           }
@@ -2523,18 +2523,22 @@ int MParConfigShow(
 
     /* FS policies */
 
-    sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pFSPolicy],MFSPolicyType[F->FSPolicy]);
+    sprintf(temp_str,"%-30s  %s\n",MParam[pFSPolicy],MFSPolicyType[F->FSPolicy]);
+    strcat(Buffer,temp_str);
 
-    sprintf(Buffer,"%s%-30s  %s%s\n",
-      Buffer,
+    sprintf(temp_str,"%-30s  %s%s\n",
       MParam[pFSPolicy],MFSPolicyType[F->FSPolicy],
       (MSched.PercentBasedFS == TRUE) ? "%" : "");
+    strcat(Buffer,temp_str);
 
     if ((F->FSPolicy == fspNONE) || (VFlag || (PIndex == -1) || (PIndex == pFSPolicy)))
       {
-      sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pFSInterval],MULToTString(F->FSInterval));
-      sprintf(Buffer,"%s%-30s  %d\n",Buffer,MParam[pFSDepth],F->FSDepth);
-      sprintf(Buffer,"%s%-30s  %-6.2f\n",Buffer,MParam[pFSDecay],F->FSDecay);
+      sprintf(temp_str,"%-30s  %s\n",MParam[pFSInterval],MULToTString(F->FSInterval));
+      strcat(Buffer,temp_str);
+      sprintf(temp_str,"%-30s  %d\n",MParam[pFSDepth],F->FSDepth);
+      strcat(Buffer,temp_str);
+      sprintf(temp_str,"%-30s  %-6.2f\n",MParam[pFSDecay],F->FSDecay);
+      strcat(Buffer,temp_str);
 
       strcat(Buffer,"\n");
       }

--- a/src/moab/MPriority.c
+++ b/src/moab/MPriority.c
@@ -195,9 +195,9 @@ int MJobGetStartPriority(
           case mpsCQ: strcat(tmpHeader,"  QOS"); break;        
           }
 
-        sprintf(tmpCWLine,"%s%5ld",
-          tmpCWLine,
+        sprintf(temp_str,"%5ld",
           (long)SWeight[index]);
+        strcat(tmpCWLine,temp_str);
         }  /* END for (index) */
 
       if (tmpHeader[0] != '\0')
@@ -236,9 +236,9 @@ int MJobGetStartPriority(
           case mpsFQ: strcat(tmpHeader,"  QOS"); break;
           }  /* END switch(index) */
  
-        sprintf(tmpCWLine,"%s%5ld",
-          tmpCWLine,
+        sprintf(temp_str,"%5ld",
           SWeight[index]);
+        strcat(tmpCWLine,temp_str);
         }  /* END for (index) */
  
       if (tmpHeader[0] != '\0')
@@ -355,9 +355,9 @@ int MJobGetStartPriority(
           case mpsSBP:  strcat(tmpHeader,"Bypas"); break;
           }
  
-        sprintf(tmpCWLine,"%s%5ld",
-          tmpCWLine,
+        sprintf(temp_str,"%5ld",
           SWeight[index]);
+        strcat(tmpCWLine,temp_str);
         }  /* END for (index) */
  
       if (tmpHeader[0] != '\0')
@@ -393,9 +393,9 @@ int MJobGetStartPriority(
           case mpsTXF: strcat(tmpHeader,"XFctr"); break;
           }
  
-        sprintf(tmpCWLine,"%s%5ld",
-          tmpCWLine,
+        sprintf(temp_str,"%5ld",
           SWeight[index]);
+        strcat(tmpCWLine,temp_str);
         }  /* END for (index) */
  
       if (tmpHeader[0] != '\0')
@@ -439,9 +439,9 @@ int MJobGetStartPriority(
           case mpsRWallTime: strcat(tmpHeader,"WTime"); break;  
           }
  
-        sprintf(tmpCWLine,"%s%5ld",
-          tmpCWLine,
+        sprintf(temp_str,"%5ld",
           SWeight[index]);
+        strcat(tmpCWLine,temp_str);
         }  /* END for (index) */
  
       if (tmpHeader[0] != '\0')
@@ -478,9 +478,9 @@ int MJobGetStartPriority(
           case mpsUPerC:     strcat(tmpHeader,"PerC "); break;
           }
  
-        sprintf(tmpCWLine,"%s%5ld",
-          tmpCWLine,
+        sprintf(temp_str,"%5ld",
           SWeight[index]);
+        strcat(tmpCWLine,temp_str);
         }  /* END for (index) */
  
       if (tmpHeader[0] != '\0')
@@ -627,9 +627,9 @@ int MJobGetStartPriority(
               ABS(((double)TotalSFactor[sindex] * SWeight[sindex] * CWeight[cindex] * 100.0 / TotalPriority)) :
               0.0);
 
-          sprintf(tmpLine,"%s%5.5s",
-            tmpLine,
+          sprintf(temp_str,"%5.5s",
             tmpS);
+          strcat(tmpLine,temp_str);
           }  /* END for (sindex) */
  
         if (tmpLine[0] != '\0')
@@ -1176,9 +1176,9 @@ int MJobGetStartPriority(
 
         sprintf(tmpS,"%3.1lf",ABS(SFactor[index]));
          
-        sprintf(tmpLine,"%s%5.5s",
-          tmpLine,
+        sprintf(temp_str,"%5.5s",
           tmpS); 
+        strcat(tmpLine,temp_str);
         }  /* END for (index) */
  
       if (tmpLine[0] != '\0')
@@ -1211,9 +1211,9 @@ int MJobGetStartPriority(
         sprintf(tmpS,"%3.1lf",
           tmpD);
  
-        sprintf(tmpLine,"%s%5.5s",
-          tmpLine,
+        sprintf(temp_str,"%5.5s",
           tmpS); 
+        strcat(tmpLine,temp_str);
         }  /* END for (index) */
  
       if (tmpLine[0] != '\0')
@@ -1246,9 +1246,9 @@ int MJobGetStartPriority(
         sprintf(tmpS,"%3.1lf",
           tmpD);
 
-        sprintf(tmpLine,"%s%5.5s",
-          tmpLine,
+        sprintf(temp_str,"%5.5s",
           tmpS);
+        strcat(tmpLine,temp_str);
         }  /* END for (index) */
 
       if (tmpLine[0] != '\0')
@@ -1281,9 +1281,9 @@ int MJobGetStartPriority(
         sprintf(tmpS,"%3.1lf",
           tmpD);
  
-        sprintf(tmpLine,"%s%5.5s",
-          tmpLine,
+        sprintf(temp_str,"%5.5s",
           tmpS);
+        strcat(tmpLine,temp_str);
         }  /* END for (index) */
  
       if (tmpLine[0] != '\0')
@@ -1316,9 +1316,9 @@ int MJobGetStartPriority(
         sprintf(tmpS,"%3.1lf",
           CP[mpcTarg]);
  
-        sprintf(tmpLine,"%s%5.5s",
-          tmpLine,
+        sprintf(temp_str,"%5.5s",
           tmpS);
+        strcat(tmpLine,temp_str);
         }  /* END for (index) */
  
       if (tmpLine[0] != '\0')
@@ -1351,9 +1351,9 @@ int MJobGetStartPriority(
         sprintf(tmpS,"%3.1lf",
           tmpD);
  
-        sprintf(tmpLine,"%s%5.5s",
-          tmpLine,
+        sprintf(temp_str,"%5.5s",
           tmpS);
+        strcat(tmpLine,temp_str);
         }  /* END for (index) */
  
       if (tmpLine[0] != '\0')
@@ -1386,9 +1386,9 @@ int MJobGetStartPriority(
         sprintf(tmpS,"%3.1lf", 
           tmpD);
  
-        sprintf(tmpLine,"%s%5.5s",
-          tmpLine,
+        sprintf(temp_str,"%5.5s",
           tmpS);
+        strcat(tmpLine,temp_str);
         }  /* END for (index) */
  
       if (tmpLine[0] != '\0')

--- a/src/moab/MQOS.c
+++ b/src/moab/MQOS.c
@@ -907,15 +907,15 @@ char *MQOSBMToString(
 
     if (Q->Name[0] != '\0')
       { 
-      sprintf(tmpLine,"%s%s",
-        tmpLine,
+      sprintf(temp_str,"%s",
         Q->Name);
+      strcat(tmpLine,temp_str);
       }
     else
       {
-      sprintf(tmpLine,"%s%d",
-        tmpLine,
+      sprintf(temp_str,"%d",
         Q->Index);
+      strcat(tmpLine,temp_str);
       }
     }  /* END for (bindex) */
  
@@ -1048,10 +1048,10 @@ int MQOSShow(
  
       if (MUBMCheck(qindex,U->F.QAL))
         {
-        sprintf(Line,"%s %s%s",
-          Line,
+        sprintf(temp_str," %s%s",
           U->Name,
           MQALType[U->F.QALType]);
+        strcat(Line,temp_str);
         }
       }  /* END for (index) */
  
@@ -1074,10 +1074,10 @@ int MQOSShow(
  
       if (MUBMCheck(qindex,G->F.QAL))
         {
-        sprintf(Line,"%s %s%s",
-          Line,
+        sprintf(temp_str," %s%s",
           G->Name,
           MQALType[G->F.QALType]);
+        strcat(Line,temp_str);
         }
       }  /* END for (index) */
  
@@ -1100,10 +1100,10 @@ int MQOSShow(
  
       if (MUBMCheck(qindex,A->F.QAL))
         {
-        sprintf(Line,"%s %s%s",
-          Line,
+        sprintf(temp_str," %s%s",
           A->Name,
           MQALType[A->F.QALType]);
+        strcat(Line,temp_str);
         }
       }  /* END for (index) */
  
@@ -1126,10 +1126,10 @@ int MQOSShow(
 
       if (MUBMCheck(qindex,C->F.QAL))
         {
-        sprintf(Line,"%s %s%s",
-          Line,
+        sprintf(temp_str," %s%s",
           C->Name,
           MQALType[C->F.QALType]);
+        strcat(Line,temp_str);
         }
       }  /* END for (index) */
 
@@ -1811,9 +1811,9 @@ char *MQOSFlagsToString(
           break; 
           }
 
-        sprintf(Line,"%s:%s",
-          Line,
+        sprintf(temp_str,":%s",
           Q->ResName[rindex]);
+        strcat(Line,temp_str);
         }  /* END for (rindex) */
       }
     }
@@ -1863,10 +1863,10 @@ int MQOSConfigLShow(
       continue;
       }
 
-    sprintf(Buffer,"%s %s=%s",
-      Buffer,
+    sprintf(temp_str," %s=%s",
       MQOSAttr[AList[aindex]],
       tmpString);
+    strcat(Buffer,temp_str);
     }  /* END for (aindex) */
 
   return(SUCCESS);

--- a/src/moab/MQueue.c
+++ b/src/moab/MQueue.c
@@ -960,10 +960,10 @@ int MQueueDiagnose(
 
   /* NOTE:  must be synchronized with MQueueSelectJobs() and MJobCheckPolicies() */
  
-  sprintf(Buffer,"%sDiagnosing blocked jobs (policylevel %s  partition %s)\n\n",
-    Buffer,
+  sprintf(temp_str,"Diagnosing blocked jobs (policylevel %s  partition %s)\n\n",
     MPolicyMode[PLevel],
     PS->Name);
+  strcat(Buffer,temp_str);
  
   if ((FullQ[0]->Next == NULL) || (FullQ[0]->Next == FullQ[0]))
     {
@@ -1021,10 +1021,10 @@ int MQueueDiagnose(
  
     if ((J->State != mjsIdle) && (J->State != mjsHold))
       {
-      sprintf(Buffer,"%sjob %-20s has non-idle state (state: '%s')\n",
-        Buffer,
+      sprintf(temp_str,"job %-20s has non-idle state (state: '%s')\n",
         J->Name,
         MJobState[J->State]);
+      strcat(Buffer,temp_str);
  
       continue;
       }
@@ -1033,10 +1033,9 @@ int MQueueDiagnose(
  
     if (J->Hold != 0)
       {
-      sprintf(Buffer,"%sjob %-20s has the following hold(s) in place: ",
-        Buffer,
+      sprintf(temp_str,"job %-20s has the following hold(s) in place: ",
         J->Name);
- 
+      strcat(Buffer,temp_str);
       for (index = 0;MHoldType[index] != NULL;index++)
         {
         if (J->Hold & (1 << index))
@@ -1055,11 +1054,10 @@ int MQueueDiagnose(
  
     if (J->EState != mjsIdle)
       {
-      sprintf(Buffer,"%sjob %-20s has non-idle expected state (expected state: %s)\n",
-        Buffer,
+      sprintf(temp_str,"job %-20s has non-idle expected state (expected state: %s)\n",
         J->Name,
         MJobState[J->EState]);
- 
+      strcat(Buffer,temp_str);
       IsBlocked = TRUE;
       }
  
@@ -1067,10 +1065,10 @@ int MQueueDiagnose(
  
     if (J->SMinTime > MSched.Time)
       {
-      sprintf(Buffer,"%sjob %-20s has not reached its start date (%s to startdate)\n",
-        Buffer,
+      sprintf(temp_str,"job %-20s has not reached its start date (%s to startdate)\n",
         J->Name,
         MULToTString(J->SMinTime - MSched.Time));
+      strcat(Buffer,temp_str);
  
       IsBlocked = TRUE;
       }
@@ -1079,11 +1077,11 @@ int MQueueDiagnose(
  
     if (MJobCheckDependency(J,&DType,DValue) == FAILURE)
       {
-      sprintf(Buffer,"%sjob %s requires %s of job '%s')\n",
-        Buffer,
+      sprintf(temp_str,"job %s requires %s of job '%s')\n",
         J->Name, 
         MJobDependType[DType],
         DValue);
+      strcat(Buffer,temp_str);
  
       IsBlocked = TRUE;
       }  /* END if (MJobCheckDependency(J,&DType,DValue) == FAILURE) */
@@ -1094,9 +1092,9 @@ int MQueueDiagnose(
         J->Name,
         PS->Name);
  
-      sprintf(Buffer,"%sjob %-20s would violate 'local' fairness policies\n",
-        Buffer,
+      sprintf(temp_str,"job %-20s would violate 'local' fairness policies\n",
         J->Name);
+      strcat(Buffer,temp_str);
  
       IsBlocked = TRUE;
       }
@@ -1121,12 +1119,11 @@ int MQueueDiagnose(
         {
         /* required classes not configured in partition */
  
-        sprintf(Buffer,"%sjob %-20s requires classes not configured in partition %s (%s)\n",
-          Buffer,
+        sprintf(temp_str,"job %-20s requires classes not configured in partition %s (%s)\n",
           J->Name,
           P->Name,
           MUCAListToString(RQ->DRes.PSlot,P->CRes.PSlot,NULL));
-
+        strcat(Buffer,temp_str);
         IsBlocked = TRUE;
  
         continue;
@@ -1134,11 +1131,11 @@ int MQueueDiagnose(
  
       if (MUBMCheck(P->Index,J->PAL) == FAILURE)
         { 
-        sprintf(Buffer,"%sjob %-20s not allowed to run in partition %s  (partitions allowed: %s)\n",
-          Buffer,
+        sprintf(temp_str,"job %-20s not allowed to run in partition %s  (partitions allowed: %s)\n",
           J->Name,
           P->Name,
           MUListAttrs(ePartition,J->PAL[0]));
+        strcat(Buffer,temp_str);
 
         IsBlocked = TRUE;
  
@@ -1173,11 +1170,11 @@ int MQueueDiagnose(
             J->Name,
             MXO[OIndex]);
  
-          sprintf(Buffer,"%sjob %-20s would violate %s FS cap in partition %s\n",
-            Buffer,
+          sprintf(temp_str,"job %-20s would violate %s FS cap in partition %s\n",
             J->Name,
             MXO[OIndex],
             P->Name);
+          strcat(Buffer,temp_str);
 
           IsBlocked = TRUE;
  
@@ -1192,9 +1189,9 @@ int MQueueDiagnose(
         {
         case mjneIdlePolicy:
 
-          sprintf(Buffer,"%sjob %-20s is blocked by idle job policy\n",
-            Buffer,
+          sprintf(temp_str,"job %-20s is blocked by idle job policy\n",
             J->Name);
+          strcat(Buffer,temp_str);
 
           break;
 
@@ -1202,9 +1199,9 @@ int MQueueDiagnose(
 
           if ((PLevel == ptHARD) || (PLevel == ptOFF))
             {
-            sprintf(Buffer,"%sjob %-20s is not blocked at this policy level\n",
-              Buffer,
+            sprintf(temp_str,"job %-20s is not blocked at this policy level\n",
               J->Name);
+            strcat(Buffer,temp_str);
             }
 
           break;

--- a/src/moab/MRM.c
+++ b/src/moab/MRM.c
@@ -2174,9 +2174,9 @@ int MRMAToString(
 
         if (R->SubType != mrmstNONE)
           {
-          sprintf(SVal,"%s:%s",
-            SVal,
+          sprintf(temp_str,":%s",
             MRMSubType[R->SubType]);
+          strcat(SVal,temp_str);
           }
         }    /* END if (R->Type != mrmtNONE) */
 
@@ -2708,10 +2708,10 @@ int MRMConfigShow(
 
       if (tmpVal[0] != '\0')
         {
-        sprintf(tmpLine,"%s %s=%s",
-          tmpLine,
+        sprintf(temp_str," %s=%s",
           MRMAttr[AList[aindex]],
           tmpVal);
+        strcat(tmpLine,temp_str);
         }
       }    /* END for (aindex) */
  
@@ -4607,9 +4607,9 @@ int MRMJobPostUpdate(
 
           if (strlen(Message) + 100 < sizeof(Message))
             {
-            sprintf(Message,"%s '%s' ",
-              Message,
+            sprintf(temp_str," '%s' ",
               N->Name);
+            strcat(Message,temp_str);
             }
 
           if (N->DRes.Procs >= N->CRes.Procs)

--- a/src/moab/MRes.c
+++ b/src/moab/MRes.c
@@ -1031,20 +1031,19 @@ int MResAToString(
           case mcmpSSUB:
           case mcmpSNE:
 
-            sprintf(Buf,"%s%s=%s",
-              Buf,
+            sprintf(temp_str,"%s=%s",
               MAttrO[(int)R->CL[aindex].Type],
               R->CL[aindex].Name);
+            strcat(Buf,temp_str);
 
             break;
 
           default:
 
-            sprintf(Buf,"%s%s=%ld",
-              Buf,
+            sprintf(temp_str,"%s=%ld",
               MAttrO[(int)R->CL[aindex].Type],
               R->CL[aindex].Value);
- 
+            strcat(Buf,temp_str);
             break;
           }  /* END switch(R->CL[aindex].Cmp) */
         }    /* END for (aindex) */
@@ -6908,9 +6907,9 @@ int MResShowState(
 
   if (R->Priority > 0)
     {
-    sprintf(tmpLine,"%s   Priority=%ld",
-      tmpLine,
+    sprintf(temp_str,"   Priority=%ld",
       R->Priority);
+    strcat(tmpLine,temp_str);
     }
 
   if (R->SystemID != NULL)
@@ -6922,9 +6921,9 @@ int MResShowState(
 
   if (R->MaxTasks > 0)
     {
-    sprintf(tmpLine,"%s   MaxTasks=%d",
-      tmpLine,
+    sprintf(temp_str,"   MaxTasks=%d",
       R->MaxTasks);
+    strcat(tmpLine,temp_str);
     }
 
   if (R->CBHost[0] != '\0')
@@ -6946,11 +6945,11 @@ int MResShowState(
         }
       }   /* END for (index) */
 
-    sprintf(tmpLine,"%s   CBServer=%s:%d/%s",
-      tmpLine,
+    sprintf(temp_str,"   CBServer=%s:%d/%s",
       R->CBHost,
       R->CBPort,
       tmpCBLine);
+    strcat(tmpLine,temp_str);
     }  /* END if (R->CBHost[0] != '\0') */
 
   if (tmpLine[0] != '\0')

--- a/src/moab/MSR.c
+++ b/src/moab/MSR.c
@@ -1236,30 +1236,30 @@ int MSRShow(
       continue;
       }
 
-    sprintf(SRLine,"%s%s=%s  ",
-      SRLine,
+    sprintf(temp_str,"%s=%s  ",
       MSResAttr[AList[index].PIndex],
       tmpLine);
+    strcat(SRLine,temp_str);
     }  /* END for (index) */
 
   /* show general attributes */
 
   if (SR->TaskCount != 0)
     {
-    sprintf(SRLine,"%s%s=%d  ",
-      SRLine,
+    sprintf(temp_str,"%s=%d  ",
       MSResAttr[msraTaskCount],
       SR->TaskCount);
+    strcat(SRLine,temp_str);
     }  /* END if (SR->TaskCount != 0) */
 
   /* show hostlist */
 
   if (SR->HostExpression[0] != '\0')
     {
-    sprintf(SRLine,"%s%s=%s  ",
-      SRLine,
+    sprintf(temp_str,"%s=%s  ",
       MSResAttr[msraHostList],
       SR->HostExpression);
+    strcat(SRLine,temp_str);
     }  /* END if (SR->HostExpression[0] != '\0') */
 
   /* show all flags */
@@ -1268,20 +1268,20 @@ int MSRShow(
     {
     char tmpLine[MAX_MLINE];
 
-    sprintf(SRLine,"%s%s=%s  ",
-      SRLine,
+    sprintf(temp_str,"%s=%s  ",
       MSResAttr[msraFlags],
       MUBMToString(SR->Flags,MResFlags,' ',tmpLine,NONE));
+    strcat(SRLine,temp_str);
     }
 
   strcpy(tmpLine,MUMAList(eFeature,SR->FeatureMap,sizeof(SR->FeatureMap)));
  
   if (strcmp(tmpLine,NONE))
     {
-    sprintf(SRLine,"%s%s=%s  ",
-      SRLine,
+    sprintf(temp_str,"%s=%s  ",
       MSResAttr[msraNodeFeatures],
       tmpLine);
+    strcat(SRLine,temp_str);
     }
 
   MUShowSSArray(MSRCfgParm,SR->Name,SRLine,Buffer);      
@@ -1903,9 +1903,9 @@ int MSRSetRes(
     strcpy(J->Name,SR->Name);
     }
 
-  sprintf(J->Name,"%s.%d",
-    J->Name,
+  sprintf(temp_str,".%d",
     DIndex);
+  strcat(J->Name,temp_str);
 
   J->SpecFlags |= (1 << mjfResMap);
 
@@ -2439,9 +2439,9 @@ int MSRUpdate(
           strcpy(ResName,SR->Name);
           }
 
-        sprintf(ResName,"%s.%d",
-          ResName,
+        sprintf(temp_str,".%d",
           DIndex);
+        strcat(ResName,temp_str);
 
         /* determine unique reservation name */
 

--- a/src/moab/MSched.c
+++ b/src/moab/MSched.c
@@ -3353,18 +3353,20 @@ int MSchedOConfigShow(
 
   S = &MSched;
 
-  sprintf(Buffer,"%s%-30s  %s\n",
-    Buffer,
+  sprintf(temp_str,"%-30s  %s\n",
     MParam[pRMPollInterval],
-    MULToTString(S->RMPollInterval));    
+    MULToTString(S->RMPollInterval));
+  strcat(Buffer,temp_str);
 
   if (S->ComputeHost[0] != NULL)
     {
-    sprintf(Buffer,"%s%-30s  %s",Buffer,MParam[mcoComputeHosts],S->ComputeHost[0]);
+    sprintf(temp_str,"%-30s  %s",MParam[mcoComputeHosts],S->ComputeHost[0]);
+    strcat(Buffer,temp_str);
 
     for (index = 1;S->ComputeHost[index] != NULL;index++)
       {
-      sprintf(Buffer,"%s %s",Buffer,S->ComputeHost[index]);
+      sprintf(temp_str," %s",S->ComputeHost[index]);
+      strcat(Buffer,temp_str);
       }  /* END for (index) */
 
     strcat(Buffer,"\n");
@@ -3376,52 +3378,57 @@ int MSchedOConfigShow(
 
   if ((S->RMJobAggregationTime > 0) || VFlag)
     {
-    sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pJobAggregationTime],
+    sprintf(temp_str,"%-30s  %s\n",MParam[pJobAggregationTime],
       MULToTString(S->RMJobAggregationTime));    
+    strcat(Buffer,temp_str);
     }
 
   if (VFlag || (PIndex == -1) || (PIndex == pNAPolicy))
     {
-    sprintf(Buffer,"%s%-30s  %s\n",
-      Buffer,
+    sprintf(temp_str,"%-30s  %s\n",
       MParam[pNAPolicy],
       MNAccessPolicy[MSched.DefaultNAccessPolicy]);
+    strcat(Buffer,temp_str);
     }
 
   if (VFlag || (PIndex == -1) || (MSched.AllocLocalityPolicy != malpNONE))
     {
-    sprintf(Buffer,"%s%-30s  %s\n",
-      Buffer,
+    sprintf(temp_str,"%-30s  %s\n",
       MParam[mcoAllocLocalityPolicy],
       MAllocLocalityPolicy[MSched.AllocLocalityPolicy]);
+    strcat(Buffer,temp_str);
     }
 
   if (VFlag || (PIndex == -1) || (MSched.TimePolicy != mtpNONE))
     {
-    sprintf(Buffer,"%s%-30s  %s\n",
-      Buffer,
+    sprintf(temp_str,"%-30s  %s\n",
       MParam[mcoTimePolicy],
       MTimePolicy[MSched.TimePolicy]);
+    strcat(Buffer,temp_str);
     }
 
   /* display security parameters */
 
-  sprintf(Buffer,"%s%-30s  %s",Buffer,MParam[mcoAdmin1Users],S->Admin1User[0]);
+  sprintf(temp_str,"%-30s  %s",MParam[mcoAdmin1Users],S->Admin1User[0]);
+  strcat(Buffer,temp_str);
 
   for (index = 1;S->Admin1User[index][0] != '\0';index++)
     {
-    sprintf(Buffer,"%s %s",Buffer,S->Admin1User[index]);
+    sprintf(temp_str," %s",S->Admin1User[index]);
+    strcat(Buffer,temp_str);
     }  /* END for (index) */
 
   strcat(Buffer,"\n");
 
   if (S->Admin2User[0][0] != '\0')
     {
-    sprintf(Buffer,"%s%-30s  %s",Buffer,MParam[mcoAdmin2Users],S->Admin2User[0]);
+    sprintf(temp_str,"%-30s  %s",MParam[mcoAdmin2Users],S->Admin2User[0]);
+    strcat(Buffer,temp_str);
 
     for (index = 1;S->Admin2User[index][0] != '\0';index++)
       {
-      sprintf(Buffer,"%s %s",Buffer,S->Admin2User[index]);
+      sprintf(temp_str," %s",S->Admin2User[index]);
+      strcat(Buffer,temp_str);
       }  /* END for (index) */
 
     strcat(Buffer,"\n");
@@ -3429,11 +3436,13 @@ int MSchedOConfigShow(
 
   if (S->Admin3User[0][0] != '\0')
     {
-    sprintf(Buffer,"%s%-30s  %s",Buffer,MParam[mcoAdmin3Users],S->Admin3User[0]);
+    sprintf(temp_str,"%-30s  %s",MParam[mcoAdmin3Users],S->Admin3User[0]);
+    strcat(Buffer,temp_str);
 
     for (index = 1;S->Admin3User[index][0] != '\0';index++)
       {
-      sprintf(Buffer,"%s %s",Buffer,S->Admin3User[index]);
+      sprintf(temp_str," %s",S->Admin3User[index]);
+      strcat(Buffer,temp_str);
       }  /* END for (index) */
 
     strcat(Buffer,"\n");
@@ -3441,11 +3450,13 @@ int MSchedOConfigShow(
 
   if (S->Admin4User[0][0] != '\0')
     {
-    sprintf(Buffer,"%s%-30s  %s",Buffer,MParam[mcoAdmin4Users],S->Admin4User[0]);
+    sprintf(temp_str,"%-30s  %s",MParam[mcoAdmin4Users],S->Admin4User[0]);
+    strcat(Buffer,temp_str);
 
     for (index = 1;S->Admin4User[index][0] != '\0';index++)
       {
-      sprintf(Buffer,"%s %s",Buffer,S->Admin4User[index]);
+      sprintf(temp_str," %s",S->Admin4User[index]);
+      strcat(Buffer,temp_str);
       }  /* END for (index) */
 
     strcat(Buffer,"\n");
@@ -3453,20 +3464,23 @@ int MSchedOConfigShow(
 
   if ((S->AdminHost[0][0] != '\0') || (VFlag || (PIndex == -1) || (PIndex == mcoAdminHosts)))
     {
-    sprintf(Buffer,"%s%-30s  %s",Buffer,MParam[mcoAdminHosts],S->AdminHost[0]);
+    sprintf(temp_str,"%-30s  %s",MParam[mcoAdminHosts],S->AdminHost[0]);
+    strcat(Buffer,temp_str);
 
     for (index = 1;index < MAX_MADMINHOSTS;index++)
       {
       if (S->AdminHost[index][0] == '\0')
         break;
 
-      sprintf(Buffer,"%s  %s",Buffer,S->AdminHost[index]);
+      sprintf(temp_str,"  %s",S->AdminHost[index]);
+      strcat(Buffer,temp_str);
       }  /* END for (index) */
 
     strcat(Buffer,"\n");
     }
 
-  sprintf(Buffer,"%s%-30s  %d\n",Buffer,MParam[pNodePollFrequency],S->NodePollFrequency);
+  sprintf(temp_str,"%-30s  %d\n",MParam[pNodePollFrequency],S->NodePollFrequency);
+  strcat(Buffer,temp_str);
 
   if ((PIndex == pDisplayFlags) || 
       (S->DisplayFlags != 0) || (VFlag || (PIndex == -1)))
@@ -3486,71 +3500,93 @@ int MSchedOConfigShow(
         }
       }
 
-    sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pDisplayFlags],tmpLine);
+    sprintf(temp_str,"%-30s  %s\n",MParam[pDisplayFlags],tmpLine);
+    strcat(Buffer,temp_str);
     }  /* END if ((PIndex == pDisplayFlags) || ...) */
 
   if ((S->DefaultDomain[0] != '\0') || 
       (VFlag || (PIndex == -1) || (PIndex == pDefaultDomain)))
     {
-    sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pDefaultDomain],S->DefaultDomain);
+    sprintf(temp_str,"%-30s  %s\n",MParam[pDefaultDomain],S->DefaultDomain);
+    strcat(Buffer,temp_str);
     }
 
   if (!strcmp(S->DefaultClassList,DEFAULT_CLASSLIST) || 
      (VFlag || (PIndex == -1) || (PIndex == pDefaultClassList)))
     {
-    sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pDefaultClassList],S->DefaultClassList);
+    sprintf(temp_str,"%-30s  %s\n",MParam[pDefaultClassList],S->DefaultClassList);
+    strcat(Buffer,temp_str);
     }
 
   if ((S->NodeTypeFeatureHeader[0] != '\0') || 
       (VFlag || (PIndex == -1) || (PIndex == pNodeTypeFeatureHeader)))
     {
-    sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pNodeTypeFeatureHeader],S->NodeTypeFeatureHeader);
+    sprintf(temp_str,"%-30s  %s\n",MParam[pNodeTypeFeatureHeader],S->NodeTypeFeatureHeader);
+    strcat(Buffer,temp_str);
     }
 
   if ((S->ProcSpeedFeatureHeader[0] != '\0') || 
       (VFlag || (PIndex == -1) || (PIndex == pProcSpeedFeatureHeader)))
     {
-    sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pProcSpeedFeatureHeader],S->ProcSpeedFeatureHeader);
+    sprintf(temp_str,"%-30s  %s\n",MParam[pProcSpeedFeatureHeader],S->ProcSpeedFeatureHeader);
+    strcat(Buffer,temp_str);
     }
 
   if ((S->PartitionFeatureHeader[0] != '\0') || 
       (VFlag || (PIndex == -1) || (PIndex == pPartitionFeatureHeader)))
     {
-    sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pPartitionFeatureHeader],S->PartitionFeatureHeader);
+    sprintf(temp_str,"%-30s  %s\n",MParam[pPartitionFeatureHeader],S->PartitionFeatureHeader);
+    strcat(Buffer,temp_str);
     }
 
   /* general sched config */
 
-  sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[mcoDeferTime],MULToTString(S->DeferTime));
-  sprintf(Buffer,"%s%-30s  %d\n",Buffer,MParam[pDeferCount],S->DeferCount);
-  sprintf(Buffer,"%s%-30s  %d\n",Buffer,MParam[pDeferStartCount],S->DeferStartCount);
+  sprintf(temp_str,"%-30s  %s\n",MParam[mcoDeferTime],MULToTString(S->DeferTime));
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %d\n",MParam[pDeferCount],S->DeferCount);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %d\n",MParam[pDeferStartCount],S->DeferStartCount);
+  strcat(Buffer,temp_str);
 
-  sprintf(Buffer,"%s%-30s  %ld\n",Buffer,MParam[pJobPurgeTime],S->JobPurgeTime);
-  sprintf(Buffer,"%s%-30s  %ld\n",Buffer,MParam[pNodePurgeTime],S->NodePurgeTime);
+  sprintf(temp_str,"%-30s  %ld\n",MParam[pJobPurgeTime],S->JobPurgeTime);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %ld\n",MParam[pNodePurgeTime],S->NodePurgeTime);
+  strcat(Buffer,temp_str);
 
-  sprintf(Buffer,"%s%-30s  %d\n",Buffer,MParam[pAPIFailureThreshhold],S->APIFailureThreshhold);
+  sprintf(temp_str,"%-30s  %d\n",MParam[pAPIFailureThreshhold],S->APIFailureThreshhold);
+  strcat(Buffer,temp_str);
 
-  sprintf(Buffer,"%s%-30s  %ld\n",Buffer,MParam[pNodeSyncDeadline],S->NodeSyncDeadline);
-  sprintf(Buffer,"%s%-30s  %ld\n",Buffer,MParam[pJobSyncDeadline],S->JobSyncDeadline);
-  sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pJobMaxOverrun],MULToTString(S->JobMaxOverrun));
+  sprintf(temp_str,"%-30s  %ld\n",MParam[pNodeSyncDeadline],S->NodeSyncDeadline);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %ld\n",MParam[pJobSyncDeadline],S->JobSyncDeadline);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %s\n",MParam[pJobMaxOverrun],MULToTString(S->JobMaxOverrun));
+  strcat(Buffer,temp_str);
 
   if ((PIndex == pNodeMaxLoad) ||
      (S->DefaultN.MaxLoad > 0.0) || VFlag || (PIndex == -1))
     {
-    sprintf(Buffer,"%s%-30s  %.1lf\n",Buffer,MParam[pNodeMaxLoad],S->DefaultN.MaxLoad);
+    sprintf(temp_str,"%-30s  %.1lf\n",MParam[pNodeMaxLoad],S->DefaultN.MaxLoad);
+    strcat(Buffer,temp_str);
     }
 
   strcat(Buffer,"\n");
 
   /* display stat graph parameters */
 
-  sprintf(Buffer,"%s%-30s  %ld\n",Buffer,MParam[pPlotMinTime],MStat.P.MinTime);
-  sprintf(Buffer,"%s%-30s  %ld\n",Buffer,MParam[pPlotMaxTime],MStat.P.MaxTime);
-  sprintf(Buffer,"%s%-30s  %ld\n",Buffer,MParam[pPlotTimeScale],MStat.P.TimeStepCount);
+  sprintf(temp_str,"%-30s  %ld\n",MParam[pPlotMinTime],MStat.P.MinTime);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %ld\n",MParam[pPlotMaxTime],MStat.P.MaxTime);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %ld\n",MParam[pPlotTimeScale],MStat.P.TimeStepCount);
+  strcat(Buffer,temp_str);
 
-  sprintf(Buffer,"%s%-30s  %ld\n",Buffer,MParam[pPlotMinNode],MStat.P.MinNode);
-  sprintf(Buffer,"%s%-30s  %ld\n",Buffer,MParam[pPlotMaxNode],MStat.P.MaxNode);
-  sprintf(Buffer,"%s%-30s  %ld\n",Buffer,MParam[pPlotNodeScale],MStat.P.NodeStepCount);
+  sprintf(temp_str,"%-30s  %ld\n",MParam[pPlotMinNode],MStat.P.MinNode);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %ld\n",MParam[pPlotMaxNode],MStat.P.MaxNode);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %ld\n",MParam[pPlotNodeScale],MStat.P.NodeStepCount);
+  strcat(Buffer,temp_str);
 
   DBG(4,fUI) DPrint("INFO:     plot parameters displayed\n");
 

--- a/src/moab/MSim.c
+++ b/src/moab/MSim.c
@@ -2501,12 +2501,17 @@ int MSimShow(
  
   char tmpLine[MAX_MLINE];
  
-  sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pWorkloadTraceFile],S->WorkloadTraceFile);
-  sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pResourceTraceFile],S->ResourceTraceFile);
-  sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pSimAutoShutdown],MPolicyMode[S->AutoShutdown]);
-  sprintf(Buffer,"%s%-30s  %ld\n",Buffer,MParam[pSimStartTime],S->StartTime);
-  sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pSimScaleJobRunTime],(S->ScaleJobRunTime == TRUE) ?
+  sprintf(temp_str,"%-30s  %s\n",MParam[pWorkloadTraceFile],S->WorkloadTraceFile);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %s\n",MParam[pResourceTraceFile],S->ResourceTraceFile);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %s\n",MParam[pSimAutoShutdown],MPolicyMode[S->AutoShutdown]);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %ld\n",MParam[pSimStartTime],S->StartTime);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %s\n",MParam[pSimScaleJobRunTime],(S->ScaleJobRunTime == TRUE) ?
     "TRUE" : "FALSE");
+  strcat(Buffer,temp_str);
  
   tmpLine[0] = '\0';
  
@@ -2521,27 +2526,41 @@ int MSimShow(
       }
     }   /* END for (index) */
  
-  sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pSimFlags],tmpLine);
+  sprintf(temp_str,"%-30s  %s\n",MParam[pSimFlags],tmpLine);
+  strcat(Buffer,temp_str);
  
-  sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pSimJobSubmissionPolicy],MSimQPolicy[S->JobSubmissionPolicy]);
-  sprintf(Buffer,"%s%-30s  %d\n",Buffer,MParam[pSimInitialQueueDepth],S->InitialQueueDepth);
+  sprintf(temp_str,"%-30s  %s\n",MParam[pSimJobSubmissionPolicy],MSimQPolicy[S->JobSubmissionPolicy]);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %d\n",MParam[pSimInitialQueueDepth],S->InitialQueueDepth);
+  strcat(Buffer,temp_str);
  
-  sprintf(Buffer,"%s%-30s  %.2lf\n",Buffer,MParam[pSimWCAccuracy],S->WCAccuracy);
-  sprintf(Buffer,"%s%-30s  %.2lf\n",Buffer,MParam[pSimWCAccuracyChange],S->WCAccuracyChange);
-  sprintf(Buffer,"%s%-30s  %d\n",Buffer,MParam[pSimNodeCount],S->NodeCount);
-  sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pSimNCPolicy],MSimNCPolicy[S->NCPolicy]);
-  sprintf(Buffer,"%s%-30s  %d\n",Buffer,MParam[pSimWCScalingPercent],S->WCScalingPercent);
+  sprintf(temp_str,"%-30s  %.2lf\n",MParam[pSimWCAccuracy],S->WCAccuracy);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %.2lf\n",MParam[pSimWCAccuracyChange],S->WCAccuracyChange);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %d\n",MParam[pSimNodeCount],S->NodeCount);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %s\n",MParam[pSimNCPolicy],MSimNCPolicy[S->NCPolicy]);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %d\n",MParam[pSimWCScalingPercent],S->WCScalingPercent);
+  strcat(Buffer,temp_str);
  
   if (S->ComRate != 0.0)
     {
-    sprintf(Buffer,"%s%-30s  %4.2f\n",Buffer,MParam[pComRate],S->ComRate);
-    sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pCommunicationType],MComType[S->CommunicationType]);
-    sprintf(Buffer,"%s%-30s  %4.2f\n",Buffer,MParam[pIntraFrameCost],S->IntraFrameCost);
-    sprintf(Buffer,"%s%-30s  %4.2f\n",Buffer,MParam[pInterFrameCost],S->InterFrameCost);
+    sprintf(temp_str,"%-30s  %4.2f\n",MParam[pComRate],S->ComRate);
+    strcat(Buffer,temp_str);
+    sprintf(temp_str,"%-30s  %s\n",MParam[pCommunicationType],MComType[S->CommunicationType]);
+    strcat(Buffer,temp_str);
+    sprintf(temp_str,"%-30s  %4.2f\n",MParam[pIntraFrameCost],S->IntraFrameCost);
+    strcat(Buffer,temp_str);
+    sprintf(temp_str,"%-30s  %4.2f\n",MParam[pInterFrameCost],S->InterFrameCost);
+    strcat(Buffer,temp_str);
     }
  
-  sprintf(Buffer,"%s%-30s  %d\n",Buffer,MParam[pStopIteration],S->StopIteration);
-  sprintf(Buffer,"%s%-30s  %d\n",Buffer,MParam[pExitIteration],S->ExitIteration);
+  sprintf(temp_str,"%-30s  %d\n",MParam[pStopIteration],S->StopIteration);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %d\n",MParam[pExitIteration],S->ExitIteration);
+  strcat(Buffer,temp_str);
  
   DBG(4,fSIM) DPrint("INFO:     simulation parameters displayed\n");
  

--- a/src/moab/MStats.c
+++ b/src/moab/MStats.c
@@ -1427,18 +1427,18 @@ int MStatOpenFile(
  
     ptr = MUStrTok(NULL," \t\n",&TokPtr);
  
-    sprintf(tmpfile,"%s_%s",
-      tmpfile,
+    sprintf(temp_str,"_%s",
       ptr);
+    strcat(tmpfile,temp_str);
  
     /* get day of month */
  
     ptr = MUStrTok(NULL," \t\n",&TokPtr);
  
-    sprintf(tmpfile,"%s_%02d",
-      tmpfile,
+    sprintf(temp_str,"_%02d",
       atoi(ptr));
- 
+    strcat(tmpfile,temp_str);
+
     /* ignore time */
  
     ptr = MUStrTok(NULL," \t\n",&TokPtr);
@@ -1447,9 +1447,9 @@ int MStatOpenFile(
  
     ptr = MUStrTok(NULL," \t\n",&TokPtr); 
  
-    sprintf(tmpfile,"%s_%s",
-      tmpfile,
+    sprintf(temp_str,"_%s",
       ptr);
+    strcat(tmpfile,temp_str);
     }
   else
     {
@@ -1631,42 +1631,42 @@ int MStatBuildGrid(
 
   if (Mode & 8)
     {
-    sprintf(Buffer,"%s         ",
-      Buffer);
+    sprintf(temp_str,"         ");
+    strcat(Buffer,temp_str);
     }
   else
     {
-    sprintf(Buffer,"%s[ %5s ]",
-      Buffer,
+    sprintf(temp_str,"[ %5s ]",
       "PROCS");
+    strcat(Buffer,temp_str);
     }
 
   for (timeindex = 0;timeindex <= MStat.P.TimeStepCount;timeindex++)
     {
     if (Mode & 8)
       {
-      sprintf(Buffer,"%s   %8s   ",
-        Buffer,
+      sprintf(temp_str,"   %8s   ",
         MUBStringTime(MStat.P.TimeStep[timeindex]));
+      strcat(Buffer,temp_str);
       }
     else
       {
-      sprintf(Buffer,"%s[  %8s  ]",
-        Buffer,
+      sprintf(temp_str,"[  %8s  ]",
         MUBStringTime(MStat.P.TimeStep[timeindex]));
+      strcat(Buffer,temp_str);
       }
     }    /* END for (timeindex) */
 
   if (Mode & 8)
     {
-    sprintf(Buffer,"%s              \n",
-    Buffer);
+    sprintf(temp_str,"              \n");
+    strcat(Buffer,temp_str);
     }
   else
     {
-    sprintf(Buffer,"%s[  %8s  ]\n",
-      Buffer,
+    sprintf(temp_str,"[  %8s  ]\n",
       "TOTAL");
+    strcat(Buffer,temp_str);
     }
 
   DBG(3,fSTAT) DPrint("INFO:     stat header created\n");
@@ -1679,15 +1679,15 @@ int MStatBuildGrid(
     {
     if (Mode & 8)
       {
-      sprintf(Buffer,"%s  %4ld   ",
-        Buffer,
+      sprintf(temp_str,"  %4ld   ",
         MStat.P.NodeStep[procindex]);
+      strcat(Buffer,temp_str);
       }
     else
       {
-      sprintf(Buffer,"%s[ %4ld  ]",
-        Buffer,
+      sprintf(temp_str,"[ %4ld  ]",
         MStat.P.NodeStep[procindex]);
+      strcat(Buffer,temp_str);
       }
 
     R = &MStat.RTotal[procindex];
@@ -1750,154 +1750,154 @@ int MStatBuildGrid(
     {
     case stAvgXFactor:
 
-      sprintf(Buffer,"%s%-26s %8.4f\n",
-        Buffer,
+      sprintf(temp_str,"%-26s %8.4f\n",
         "Job Weighted XFactor:",
         (T->Count > 0) ? (double)T->XFactor / T->Count : 0.0);
+      strcat(Buffer,temp_str);
 
-      sprintf(Buffer,"%s%-26s %8.4f\n",
-        Buffer,
+      sprintf(temp_str,"%-26s %8.4f\n",
         "Proc Weighted XFactor:",
         (T->NCount > 0) ? T->NXFactor / T->NCount : 0.0);
+      strcat(Buffer,temp_str);
 
-      sprintf(Buffer,"%s%-26s %8.4f\n",
-        Buffer,
+      sprintf(temp_str,"%-26s %8.4f\n",
         "PS Weighted XFactor:",
         (T->PSRun > 0.0) ? T->PSXFactor / T->PSRun : 0.0);
+      strcat(Buffer,temp_str);
 
       break;
 
     case stMaxXFactor:
 
-      sprintf(Buffer,"%s%-26s %8.4f\n",
-        Buffer,
+      sprintf(temp_str,"%-26s %8.4f\n",
         "Overall Max XFactor:",
         (double)T->MaxXFactor);
+      strcat(Buffer,temp_str);
 
       break;
 
     case stAvgQTime:
 
-      sprintf(Buffer,"%s%-26s %8.4f\n",
-        Buffer,
+      sprintf(temp_str,"%-26s %8.4f\n",
         "Job Weighted QueueTime:",
         (T->Count > 0) ? (double)T->TotalQTS / T->Count / 3600.0 : 0.0);
+      strcat(Buffer,temp_str);
 
       break;
 
     case stAvgBypass:
 
-      sprintf(Buffer,"%s%-26s %8.4f\n",
-        Buffer,
+      sprintf(temp_str,"%-26s %8.4f\n",
         "Job Weighted X Bypass:",
         (T->Count > 0) ? (double)T->Bypass / T->Count : 0.0);
+      strcat(Buffer,temp_str);
 
       break;
 
     case stMaxBypass:
 
-      sprintf(Buffer,"%s%-26s %8d\n",
-        Buffer,
+      sprintf(temp_str,"%-26s %8d\n",
         "Overall Max Bypass:",
         T->MaxBypass);
+      strcat(Buffer,temp_str);
 
       break;
 
     case stJobCount:
 
-      sprintf(Buffer,"%s%-26s %8d\n",
-        Buffer,
+      sprintf(temp_str,"%-26s %8d\n",
         "Total Jobs:",
         T->Count);
+      strcat(Buffer,temp_str);
 
       break;
 
     case stPSRequest:
 
-      sprintf(Buffer,"%s%-26s %8.2f\n",
-        Buffer,
+      sprintf(temp_str,"%-26s %8.2f\n",
         "Total PH Requested:",
         (double)T->PSRequest / 3600.0);
+      strcat(Buffer,temp_str);
     
       break;
 
     case stPSRun:
 
-      sprintf(Buffer,"%s%-26s %8.2f\n",
-        Buffer,
+      sprintf(temp_str,"%-26s %8.2f\n",
         "Total PH Run",
         (double)T->PSRun / 3600.0);
+      strcat(Buffer,temp_str);
     
       break;
 
     case stWCAccuracy:
 
-      sprintf(Buffer,"%s%-26s %8.3f\n",
-        Buffer,
+      sprintf(temp_str,"%-26s %8.3f\n",
         "Overall WallClock Accuracy:",
         (T->PSRequest > 0.0) ? (double)T->PSRun / T->PSRequest * 100.0 : 0.0);
+      strcat(Buffer,temp_str);
 
       break;
 
     case stBFCount:
 
-      sprintf(Buffer,"%s%-26s %8.4f (%d / %d)\n",
-        Buffer,
+      sprintf(temp_str,"%-26s %8.4f (%d / %d)\n",
         "Job Weighted BackFill Job Percent:",
         (double)T->BFCount / T->Count * 100.0,
         T->BFCount,
         T->Count);
+      strcat(Buffer,temp_str);
 
       break;
 
     case stBFPSRun:
 
-      sprintf(Buffer,"%s%-26s %8.4f (%6.2f / %6.2f)\n",
-        Buffer,
+      sprintf(temp_str,"%-26s %8.4f (%6.2f / %6.2f)\n",
         "PS Weighted BackFill PS Percent:",
         T->BFPSRun / T->PSRun * 100.0,
         T->BFPSRun,
         T->PSRun);
+      strcat(Buffer,temp_str);
 
       break;
 
     case stJobEfficiency:
 
-      sprintf(Buffer,"%s%-26s %8.4f (%6.2f / %6.2f)\n",
-        Buffer,
+      sprintf(temp_str,"%-26s %8.4f (%6.2f / %6.2f)\n",
         "PS Weighted Job Efficiency Percent:",
         (T->PSDedicated > 0.0) ? T->PSUtilized / T->PSDedicated * 100.0 : 0.0,
         T->PSUtilized / 3600.0,
         T->PSDedicated / 3600.0);
+      strcat(Buffer,temp_str);
 
       break;
 
     case stQOSDelivered:
 
-      sprintf(Buffer,"%s%-26s %8.4f (%d / %d)\n",
-        Buffer,
+      sprintf(temp_str,"%-26s %8.4f (%d / %d)\n",
         "Job Weighted QOS Success Rate:",
         (T->Count > 0) ? (double)T->QOSMet / T->Count * 100.0 : 0.0,
         T->QOSMet,
         T->Count);
+      strcat(Buffer,temp_str);
 
       break;
 
     default:
 
-      sprintf(Buffer,"%sERROR:  stat type %d totals not handled\n",
-        Buffer,
+      sprintf(temp_str,"ERROR:  stat type %d totals not handled\n",
         SIndex);
+      strcat(Buffer,temp_str);
 
       break;
     }  /* END Switch(SIndex) */
 
   DBG(4,fSTAT) DPrint("INFO:     buildgrid() complete\n");
 
-  sprintf(Buffer,"%s%-26s %8d\n",
-    Buffer,
+  sprintf(temp_str,"%-26s %8d\n",
     "Total Samples:",
     T->Count);
+  strcat(Buffer,temp_str);
 
   strcat(Buffer,"\n\n");
 

--- a/src/moab/MSys.c
+++ b/src/moab/MSys.c
@@ -2722,8 +2722,7 @@ int MSysDiagnose(
 
   SBuf[0] = '\0';
 
-  sprintf(SBuf,"%sInitialized: S:%s/I:%s  CCount: %d  FCount: %d  QCount: %d  JCount: %d  RCount: %d\n",
-    SBuf,
+  sprintf(temp_str,"Initialized: S:%s/I:%s  CCount: %d  FCount: %d  QCount: %d  JCount: %d  RCount: %d\n",
     (MSched.G.SIsInitialized == TRUE) ? "TRUE" : "FALSE",
     (MSched.G.IIsInitialized == TRUE) ? "TRUE" : "FALSE",
     MSched.G.CCount,
@@ -2731,18 +2730,19 @@ int MSysDiagnose(
     MSched.G.QCount,
     MSched.G.JCount,
     MSched.G.RCount);
+  strcat(SBuf,temp_str);
 
   if (MSim.StopIteration == MSched.Iteration)
     {
-    sprintf(SBuf,"%s\nNOTE:  scheduler is currently stopped\n",
-      SBuf);
+    sprintf(temp_str,"\nNOTE:  scheduler is currently stopped\n");
+    strcat(SBuf,temp_str);
     }
 
   if (MSched.G.Messages != NULL)
     {
-    sprintf(SBuf,"%s\nMessages:\n  %s\n",
-      SBuf,
+    sprintf(temp_str,"\nMessages:\n  %s\n",
       MSched.G.Messages);
+    strcat(SBuf,temp_str);
     }
 
   return(SUCCESS);

--- a/src/moab/MTrace.c
+++ b/src/moab/MTrace.c
@@ -478,10 +478,10 @@ int MTraceBuildResource(
       for (cindex = 1;cindex < MAX_MCLASS;cindex++)
         {
         if (N->CRes.PSlot[cindex].count > 0) 
-          sprintf(Classes,"%s[%s:%d]",
-            Classes,
+          sprintf(temp_str,"[%s:%d]",
             MAList[eClass][cindex],
             N->CRes.PSlot[cindex].count);
+        strcat(Classes,temp_str);
         }  /* END for (cindex) */
 
       if (Classes[0] == '\0')

--- a/src/moab/MUI.c
+++ b/src/moab/MUI.c
@@ -89,14 +89,14 @@ int UIFormatShowAllJobs(
  
   strcpy(DstBuffer,"ACTIVE JOBS--------------------\n");
  
-  sprintf(DstBuffer,"%s%18s %8s %10s %5s %11s %20s\n\n",
-    DstBuffer,
+  sprintf(temp_str,"%18s %8s %10s %5s %11s %20s\n\n",
     "JOBNAME",
     "USERNAME",
     "STATE",
     "PROC",
     "REMAINING",
     "STARTTIME");
+  strcat(DstBuffer,temp_str);
  
   /* read all running jobs */
  
@@ -128,51 +128,51 @@ int UIFormatShowAllJobs(
  
     /* display job */
  
-    sprintf(DstBuffer,"%s%18s %8s %10s %5d %11s  %19s",
-      DstBuffer,
+    sprintf(temp_str,"%18s %8s %10s %5d %11s  %19s",
       name,
       UserName,
       MJobState[state],
       procs,
       MULToTString(cpulimit - (Now - stime)),
       MULToDString((mulong *)&stime));
+    strcat(DstBuffer,temp_str);
     }  /* END while (ptr) */
  
   sprintf(tmp,"%d Active Job%c   ",
     acount,
     (acount == 1) ? ' ' : 's');
  
-  sprintf(DstBuffer,"%s\n%21s %4d of %4d Processors Active (%.2f%c)\n",
-    DstBuffer,
+  sprintf(temp_str,"\n%21s %4d of %4d Processors Active (%.2f%c)\n",
     tmp, 
     BusyProcs,
     UpProcs,
     (UpProcs > 0) ? (double)BusyProcs / UpProcs * 100.0 : 0.0,
     '%');
+  strcat(DstBuffer,temp_str);
  
   if (UpProcs != UpNodes)
     {
-    sprintf(DstBuffer,"%s%21s %4d of %4d Nodes Active      (%.2f%c)\n",
-      DstBuffer,
+    sprintf(temp_str,"%21s %4d of %4d Nodes Active      (%.2f%c)\n",
       " ",
       BusyNodes,
       UpNodes,
       (UpNodes > 0) ? (double)BusyNodes / UpNodes * 100.0 : 0.0,
       '%');
+    strcat(DstBuffer,temp_str);
     }
  
   /* display list of idle jobs */
  
   strcat(DstBuffer,"\nIDLE JOBS----------------------\n");
  
-  sprintf(DstBuffer,"%s%18s %8s %10s %5s %11s %20s\n\n",
-    DstBuffer,
+  sprintf(temp_str,"%18s %8s %10s %5s %11s %20s\n\n",
     "JOBNAME",
     "USERNAME",
     "STATE",
     "PROC",
     "WCLIMIT",
     "QUEUETIME");
+  strcat(DstBuffer,temp_str);
  
   /* read all idle jobs */
  
@@ -221,14 +221,14 @@ int UIFormatShowAllJobs(
  
   strcat(DstBuffer,"\nBLOCKED JOBS-------------------\n");
  
-  sprintf(DstBuffer,"%s%18s %8s %10s %5s %11s %20s\n\n",
-    DstBuffer,
+  sprintf(temp_str,"%18s %8s %10s %5s %11s %20s\n\n",
     "JOBNAME",
     "USERNAME",
     "STATE",
     "PROC",
     "WCLIMIT",
     "QUEUETIME");
+  strcat(DstBuffer,temp_str);
  
   /* read all non-queued jobs */
  
@@ -262,28 +262,28 @@ int UIFormatShowAllJobs(
  
     /* display job */
  
-    sprintf(DstBuffer,"%s%18s %8s %10s %5d %11s  %19s",
-      DstBuffer,
+    sprintf(temp_str,"%18s %8s %10s %5d %11s  %19s",
       name,
       UserName,
       MJobState[state],
       procs,
       MULToTString(cpulimit),
       MULToDString((mulong *)&qtime));
+    strcat(DstBuffer,temp_str);
     }  /* END while (ptr) */
  
-  sprintf(DstBuffer,"%s\nTotal Jobs: %d   Active Jobs: %d   Idle Jobs: %d   Non-Queued Jobs: %d\n",
-    DstBuffer,
+  sprintf(temp_str,"\nTotal Jobs: %d   Active Jobs: %d   Idle Jobs: %d   Non-Queued Jobs: %d\n",
     count,
     acount,
     icount,
     ncount);
+  strcat(DstBuffer,temp_str);
  
   while ((ptr = MUStrTok(NULL,"\n",&TokPtr)) != NULL)
     {
-    sprintf(DstBuffer,"%s\n%s\n",
-      DstBuffer,
+    sprintf(temp_str,"\n%s\n",
       ptr);
+    strcat(DstBuffer,temp_str);
     }
  
   return(SUCCESS);
@@ -369,14 +369,14 @@ int UIFormatHShowAllJobs(
       {
       strcat(DstBuffer,"<TABLE BORDER=1>");
  
-      sprintf(DstBuffer,"%s<TR><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD></TR>",
-        DstBuffer,
+      sprintf(temp_str,"<TR><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD></TR>",
         "Active Jobs",
         "User Name",
         "Job State",
         "Processors",
         "Time Remaining",
         "Start Time");
+      strcat(DstBuffer,temp_str);
       }
  
     acount++;
@@ -400,40 +400,40 @@ int UIFormatHShowAllJobs(
  
     /* display job */
 
-    sprintf(DstBuffer,"%s<TR><TD>%s</TD><TD>%s</TD><TD>%s</TD><TD>%d</TD><TD>%s</TD><TD>%s</TD></TR>",  
-      DstBuffer,
+    sprintf(temp_str,"<TR><TD>%s</TD><TD>%s</TD><TD>%s</TD><TD>%d</TD><TD>%s</TD><TD>%s</TD></TR>",
       name,
       UserName,
       MJobState[state],
       procs,
       MULToTString(cpulimit - (Now - stime)),
       MULToDString((mulong *)&stime));
+    strcat(DstBuffer,temp_str);
     }  /* END while (ptr) */
 
   if (acount > 0)
     {
     strcat(DstBuffer,"</TABLE><p>");
  
-    sprintf(DstBuffer,"%s%d Active Job%c<br>",
-      DstBuffer,
+    sprintf(temp_str,"%d Active Job%c<br>",
       acount,
       (acount == 1) ? ' ' : 's');
+    strcat(DstBuffer,temp_str);
  
-    sprintf(DstBuffer,"%s%d of %d Processors Active (%.2f%c)<br>",
-      DstBuffer,
+    sprintf(temp_str,"%d of %d Processors Active (%.2f%c)<br>",
       BusyProcs,
       UpProcs,
       (UpProcs > 0) ? (double)BusyProcs / UpProcs * 100.0 : 0.0,
       '%');
+    strcat(DstBuffer,temp_str);
  
     if (UpProcs != UpNodes)
       {
-      sprintf(DstBuffer,"%s%d of %d Nodes Active (%.2f%c)<br>",
-        DstBuffer,
+      sprintf(temp_str,"%d of %d Nodes Active (%.2f%c)<br>",
         BusyNodes,
         UpNodes,
         (UpNodes > 0) ? (double)BusyNodes / UpNodes * 100.0 : 0.0,
         '%');
+      strcat(DstBuffer,temp_str);
       }
 
     strcat(DstBuffer,"<p>");
@@ -452,14 +452,14 @@ int UIFormatHShowAllJobs(
       {
       strcat(DstBuffer,"<TABLE BORDER=1>");
 
-      sprintf(DstBuffer,"%s<TR><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD></TR>", 
-        DstBuffer,
+      sprintf(temp_str,"<TR><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD></TR>",
         "Idle Jobs",
         "User Name",
         "Job State",
         "Processors",
         "WallClock Limit",
         "Submission Time");
+      strcat(DstBuffer,temp_str);
       }
   
     count++;
@@ -483,24 +483,24 @@ int UIFormatHShowAllJobs(
  
     /* display job */
 
-    sprintf(DstBuffer,"%s<TR><TD>%s</TD><TD>%s</TD><TD>%s</TD><TD>%d</TD><TD>%s</TD><TD>%s</TD></TR>",      
-      DstBuffer,
+    sprintf(temp_str,"<TR><TD>%s</TD><TD>%s</TD><TD>%s</TD><TD>%d</TD><TD>%s</TD><TD>%s</TD></TR>",
       name,
       UserName,
       MJobState[state],
       procs,
       MULToTString(cpulimit),
       MULToDString((mulong *)&qtime));
+    strcat(DstBuffer,temp_str);
     }  /* END while (ptr) */
 
   if (icount > 0)
     {
     strcat(DstBuffer,"</TABLE><p>"); 
 
-    sprintf(DstBuffer,"%s%d Idle Job%c<p>",
-      DstBuffer,
+    sprintf(temp_str,"%d Idle Job%c<p>",
       icount,
       (icount == 1) ? ' ' : 's');
+    strcat(DstBuffer,temp_str);
     }
 
   /* display ineligible jobs */
@@ -518,8 +518,7 @@ int UIFormatHShowAllJobs(
       {
       strcat(DstBuffer,"<TABLE BORDER=1>");
 
-      sprintf(DstBuffer,"%s<TR><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD></TR>", 
-        DstBuffer,
+      sprintf(temp_str,"<TR><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD><TD><B>%s</B></TD></TR>",
         "Ineligible Jobs",
         "User Name",
         "Job State",
@@ -527,6 +526,7 @@ int UIFormatHShowAllJobs(
         "WallClock Limit",
         "Submission Time",
         "Reason");
+      strcat(DstBuffer,temp_str);
       }
  
     count++;
@@ -550,8 +550,7 @@ int UIFormatHShowAllJobs(
  
     /* display job */
 
-   sprintf(DstBuffer,"%s<TR><TD>%s</TD><TD>%s</TD><TD>%s</TD><TD>%d</TD><TD>%s</TD><TD>%s</TD><TD>%s</TD></TR>",    
-      DstBuffer,
+   sprintf(temp_str,"<TR><TD>%s</TD><TD>%s</TD><TD>%s</TD><TD>%d</TD><TD>%s</TD><TD>%s</TD><TD>%s</TD></TR>",
       name,
       UserName,
       MJobState[state],
@@ -559,6 +558,7 @@ int UIFormatHShowAllJobs(
       MULToTString(cpulimit),
       MULToDString((mulong *)&qtime),
       "N/A");
+   strcat(DstBuffer,temp_str);
     }  /* END while (ptr) */
 
   if (ncount > 0)
@@ -566,18 +566,18 @@ int UIFormatHShowAllJobs(
     strcat(DstBuffer,"</TABLE><p>");     
     }
  
-  sprintf(DstBuffer,"%s<p>Total Jobs: %d &nbsp; Active Jobs: %d &nbsp; Idle Jobs: %d &nbsp; Ineligible Jobs: %d<p>",
-    DstBuffer,
+  sprintf(temp_str,"<p>Total Jobs: %d &nbsp; Active Jobs: %d &nbsp; Idle Jobs: %d &nbsp; Ineligible Jobs: %d<p>",
     count,
     acount,
     icount,
     ncount);
+  strcat(DstBuffer,temp_str);
  
   while ((ptr = MUStrTok(NULL,"\n",&TokPtr)) != NULL)
     {
-    sprintf(DstBuffer,"%s<p>%s<p>",
-      DstBuffer,
+    sprintf(temp_str,"<p>%s<p>",
       ptr);
+    strcat(DstBuffer,temp_str);
     }
 
   strcat(DstBuffer,"</FONT>");         

--- a/src/moab/MUtil.c
+++ b/src/moab/MUtil.c
@@ -1074,9 +1074,9 @@ char *MUListAttrs(
     {
     if ((Value & (1 << i)) && (MAList[Attr][i][0] != '\0'))
       {
-      sprintf(Line,"%s[%s]",
-        Line,
+      sprintf(temp_str,"[%s]",
         MAList[Attr][i]);
+      strcat(Line,temp_str);
       }
     }    /* for (i) */
 
@@ -1114,9 +1114,9 @@ char *MUMAList(
       if ((ValueMap[findex] & (1 << index)) && 
           (MAList[AttrIndex][index][0] != '\0'))
         {
-        sprintf(Line,"%s[%s]",
-          Line,
+        sprintf(temp_str,"[%s]",
           MAList[AttrIndex][index + findex * M64.INTBITS]);
+        strcat(Line,temp_str);
         }
       }    /* END for (index) */
     }      /* END for (findex) */
@@ -1267,21 +1267,21 @@ char *MUCAListToString(
       if ((CClass[cindex].count > 0) || 
           (AClass[cindex].count > 0)) 
         {
-        sprintf(ptr,"%s[%s %d:%d]",
-          ptr,
+        sprintf(temp_str,"[%s %d:%d]",
           MAList[eClass][cindex],
           AClass[cindex].count,
           CClass[cindex].count); 
         }
+      strcat(ptr,temp_str);
       }
     else
       {
       if (AClass[cindex].count > 0) 
         {
-        sprintf(ptr,"%s[%s %d]",
-          ptr,
+        sprintf(temp_str,"[%s %d]",
           MAList[eClass][cindex],
           AClass[cindex].count);
+        strcat(ptr,temp_str);
         }
       }
     }   /* END for(cindex) */
@@ -1953,19 +1953,19 @@ char *MUCResToString(
         {
         /* human readable - percent */
 
-        sprintf(Line,"%s%s: %0.2lf",
-          Line,
+        sprintf(temp_str,"%s: %0.2lf",
           N,
           (double)tmpI / 100.0);
+        strcat(Line,temp_str);
         }
       else if (DisplayMode == 2)
         {
         /* machine readable */
 
-        sprintf(Line,"%s%s=%d",
-          Line,
+        sprintf(temp_str,"%s=%d",
           N,
           tmpI);
+        strcat(Line,temp_str);
         }
       else
         {
@@ -1973,17 +1973,17 @@ char *MUCResToString(
 
         if (index > 0)
           {
-          sprintf(Line,"%s%s: %s",
-            Line,
+          sprintf(temp_str,"%s: %s",
             N,
             MULToRSpec((long)tmpI,mvmMega,NULL));
+          strcat(Line,temp_str);
           }
         else
           {
-          sprintf(Line,"%s%s: %d",
-            Line,
+          sprintf(temp_str,"%s: %d",
             N,
             tmpI);
+          strcat(Line,temp_str);
           }
         }
       }
@@ -1991,17 +1991,17 @@ char *MUCResToString(
       {
       if (DisplayMode == 2)
         {
-        sprintf(Line,"%s%s=%s",
-          Line,
+        sprintf(temp_str,"%s=%s",
           N,
           ALL);
+        strcat(Line,temp_str);
         }
       else
         {
-        sprintf(Line,"%s%s: %s",
-          Line,
+        sprintf(temp_str,"%s: %s",
           N,
           ALL);
+        strcat(Line,temp_str);
         }
       }
     }    /* END for (index)   */
@@ -2016,10 +2016,10 @@ char *MUCResToString(
     if (Line[0] != '\0')
       MUStrCat(Line,"  ",MAX_MLINE);
 
-    sprintf(Line,"%s%s: %d",
-      Line,
+    sprintf(temp_str,"%s: %d",
       MAList[eGRes][index],
       R->GRes[index].count);
+    strcat(Line,temp_str);
     }  /* END for (index) */
 
   if (Line[0] == '\0')
@@ -2407,9 +2407,9 @@ int MUREToList(
  
             if (Buffer != NULL)
               {
-              sprintf(Buffer,"%snode '%s' found\n",
-                Buffer,
+              sprintf(temp_str,"node '%s' found\n",
                 N->Name);
+              strcat(Buffer,temp_str);
               }
  
             break;
@@ -2443,9 +2443,9 @@ int MUREToList(
  
             if (Buffer != NULL)
               {
-              sprintf(Buffer,"%snode '%s' found\n",
-                Buffer,
+              sprintf(temp_str,"node '%s' found\n",
                 N->Name);
+              strcat(Buffer,temp_str);
               }
             }
           else if (!strcmp(N->Name,Match))
@@ -2490,8 +2490,8 @@ int MUREToList(
  
         if (Buffer != NULL)
           {
-          sprintf(Buffer,"%sERROR:    no matches found for node expression\n",
-            Buffer);
+          sprintf(temp_str,"ERROR:    no matches found for node expression\n");
+          strcat(Buffer,temp_str);
           }
  
         return(FAILURE);
@@ -2532,6 +2532,7 @@ int MUREToList(
               sprintf(Buffer,"%sjob '%s' found\n",
                 Buffer,
                 J->Name);
+              strcat(Buffer,temp_str);
               }
             }
           else if (!strcmp(J->Name,Match))
@@ -2574,8 +2575,8 @@ int MUREToList(
  
         if (Buffer != NULL)
           {
-          sprintf(Buffer,"%sERROR:    no matches found for job expression\n",
-            Buffer);
+          sprintf(temp_str,"ERROR:    no matches found for job expression\n");
+          strcat(Buffer,temp_str);
           }
  
         return(FAILURE);
@@ -2615,9 +2616,9 @@ int MUREToList(
 
             if (Buffer != NULL)
               {
-              sprintf(Buffer,"%sres '%s' found\n",
-                Buffer,
+              sprintf(temp_str,"res '%s' found\n",
                 R->Name);
+              strcat(Buffer,temp_str);
               }
             }
           else if (!strcmp(R->Name,Match))
@@ -2660,8 +2661,8 @@ int MUREToList(
 
         if (Buffer != NULL)
           {
-          sprintf(Buffer,"%sERROR:    no matches found for job expression\n",
-            Buffer);
+          sprintf(temp_str,"ERROR:    no matches found for job expression\n");
+          strcat(Buffer,temp_str);
           }
 
         return(FAILURE);
@@ -4128,9 +4129,9 @@ char *MUBMToString(
       {
       if (Delim == '[')
         {
-        sprintf(ptr,"%s[%s]",
-          ptr,
+        sprintf(temp_str,"[%s]",
           AList[i]);
+        strcat(ptr,temp_str);
         }
       else
         {
@@ -4424,13 +4425,13 @@ char *MUCResRatioToString(
       if (Line[0] != '\0')
         MUStrCat(Line,"  ",sizeof(Line));
 
-      sprintf(Line,"%s%s: %d/%d (%.2f%c)",
-        Line,
+      sprintf(temp_str,"%s: %d/%d (%.2f%c)",
         N,
         BVal,
         TotalRes,
         (double)BVal * 100.0 / TotalRes,
         '%');
+      strcat(Line,temp_str);
       }
     }  /* END for (index) */
  
@@ -4727,13 +4728,13 @@ int MUShowSSArray(
   char       *Buffer)    /* I/O */
  
   { 
-  sprintf(Buffer,"%s%s[%s]%-.*s  %s\n",
-    Buffer,
+  sprintf(temp_str,"%s[%s]%-.*s  %s\n",
     Param,
     IndexName,
     MCFG_HDR_LEN - 2 - (int)(strlen(Param) + strlen(IndexName)),
     "                                        ",
     (ValLine != NULL) ? ValLine : "");
+  strcat(Buffer,temp_str);
  
   return(SUCCESS);
   }  /* END MUShowSSArray() */
@@ -5452,10 +5453,10 @@ char *MUMAToString(
           {
           if (Line[0] != '\0')
             {
-            sprintf(Line,"%s%c%s",
-              Line,
+            sprintf(temp_str,"%c%s",
               Delim,
               ptr);
+            strcat(Line,temp_str);
             }
           else
             {
@@ -5464,9 +5465,9 @@ char *MUMAToString(
           }
         else
           {
-          sprintf(Line,"%s[%s]",
-            Line,
+          sprintf(temp_str,"[%s]",
             ptr);
+          strcat(Line,temp_str);
           }
         }
       }    /* END for (index) */

--- a/src/server/LLI.c
+++ b/src/server/LLI.c
@@ -1842,9 +1842,9 @@ int MLLJobLoad(
       {
       strncpy(DValue,J->Name,ptr - J->Name);
 
-      sprintf(DValue,"%s%d",
-        DValue,
+      sprintf(temp_str,"%d",
         SIndex - 1);
+      strcat(DValue,temp_str);
 
       MJobSetDependency(J,mjdJobCompletion,DValue);
       }

--- a/src/server/OUserI.c
+++ b/src/server/OUserI.c
@@ -862,16 +862,16 @@ int ShowBackfillWindow(
             {
             if ((strcasecmp(CurrentPName,GLOBAL_MPARNAME)) && (index == 0))
               {
-              sprintf(Buffer,"%sno %s available\n",
-                Buffer,
+              sprintf(temp_str,"no %s available\n",
                 (MSched.DisplayFlags & (1 << dfNodeCentric)) ? "nodes" : "procs");
               }
+            strcat(Buffer,temp_str);
 
             strcpy(CurrentPName,P->Name);
 
-            sprintf(Buffer,"%s\npartition %s:\n",
-              Buffer,
+            sprintf(temp_str,"\npartition %s:\n",
               P->Name);
+            strcat(Buffer,temp_str);
 
             index = 0;
             }
@@ -882,23 +882,23 @@ int ShowBackfillWindow(
 
             if (BFNodeCount == 0)
               {
-              sprintf(Buffer,"%sno nodes available\n",
-                Buffer);
+              sprintf(temp_str,"no nodes available\n");
+              strcat(Buffer,temp_str);
               }
             else if (BFTime < 100000000)
               {
-              sprintf(Buffer,"%s%3d node%s available for   %11s\n",
-                Buffer,
+              sprintf(temp_str,"%3d node%s available for   %11s\n",
                 BFNodeCount,
                 (BFNodeCount > 1) ? "s" : "",
                 MULToTString(BFTime));
+              strcat(Buffer,temp_str);
               }
             else
               {
-              sprintf(Buffer,"%s%3d node%s available with no timelimit\n",
-                Buffer,
+              sprintf(temp_str,"%3d node%s available with no timelimit\n",
                 BFNodeCount,
                 (BFNodeCount > 1) ? "s" : "");
+              strcat(Buffer,temp_str);
               }
             }
           else
@@ -907,23 +907,23 @@ int ShowBackfillWindow(
 
             if (BFProcCount == 0)
               {
-              sprintf(Buffer,"%sno procs available\n",
-                Buffer);
+              sprintf(temp_str,"no procs available\n");
+              strcat(Buffer,temp_str);
               }
             else if (BFTime < 100000000)
               {
-              sprintf(Buffer,"%s%3d proc%s available for   %11s\n",
-                Buffer,
+              sprintf(temp_str,"%3d proc%s available for   %11s\n",
                 BFProcCount,
                 (BFProcCount > 1) ? "s" : "",
                 MULToTString(BFTime));
+              strcat(Buffer,temp_str);
               }
             else
               {
-              sprintf(Buffer,"%s%3d proc%s available with no timelimit\n",
-                Buffer,
+              sprintf(temp_str,"%3d proc%s available with no timelimit\n",
                 BFProcCount,
                 (BFProcCount > 1) ? "s" : "");
+              strcat(Buffer,temp_str);
               }
             }
 
@@ -942,8 +942,8 @@ int ShowBackfillWindow(
 
     if (index == 0)
       {
-      sprintf(Buffer,"%sno procs available\n",
-        Buffer);
+      sprintf(temp_str,"no procs available\n");
+      strcat(Buffer,temp_str);
       }
 
     strcat(Buffer,"\n\n");
@@ -986,23 +986,23 @@ int ShowBackfillWindow(
 
     MJobBuildCL(J);
 
-    sprintf(Buffer,"%s%20s %5s %6s %7s %7s   %14s\n",
-      Buffer,
+    sprintf(temp_str,"%20s %5s %6s %7s %7s   %14s\n",
       "HostName",
       "Procs",
       "Memory",
       "Disk",
       "Swap",
       "Time Available");
+    strcat(Buffer,temp_str);
 
-    sprintf(Buffer,"%s%20s %5s %6s %7s %7s   %14s\n",
-      Buffer,
+    sprintf(temp_str,"%20s %5s %6s %7s %7s   %14s\n",
       "----------",
       "-----",
       "------",
       "-------",
       "-------",
       "--------------");
+    strcat(Buffer,temp_str);
 
     for (nindex = 0;nindex < MAX_MNODE;nindex++)
       {
@@ -1050,14 +1050,14 @@ int ShowBackfillWindow(
             NodeHeaderPrinted = TRUE;
             }
 
-          sprintf(Buffer,"%s%20s %5d %6d %7d %7d   %14s\n",
-            Buffer,
+          sprintf(temp_str,"%20s %5d %6d %7d %7d   %14s\n",
             N->Name,
             DRes.Procs,
             DRes.Mem,
             DRes.Disk,
             DRes.Swap,
             MULToTString(ARange[0].EndTime - MSched.Time));
+          strcat(Buffer,temp_str);
           }
         else
           {
@@ -1123,8 +1123,7 @@ int UINodeStatShow(
 
   sprintf(Buffer,"Memory Requirement Breakdown:\n\n");
 
-  sprintf(Buffer,"%s%8s %5s %7s %9s %7s %10s %7s\n",
-    Buffer,
+  sprintf(temp_str,"%8s %5s %7s %9s %7s %10s %7s\n",
     "Memory",
     "Proc",
     "Percent",
@@ -1132,6 +1131,7 @@ int UINodeStatShow(
     "Percent",
     "ProcHours",
     "Percent");
+  strcat(Buffer,temp_str);
 
   totalnodes = 0;
   totalworkload = 0;
@@ -1172,8 +1172,7 @@ int UINodeStatShow(
       IAverage = (double)MRClass[cindex].InitialWorkload / MRClass[cindex].Nodes / averageload * 100.0;
       }
 
-    sprintf(Buffer,"%s%8d %5d %7.2f %9ld %7.2f %10ld %7.2f\n",
-      Buffer,
+    sprintf(temp_str,"%8d %5d %7.2f %9ld %7.2f %10ld %7.2f\n",
       MRClass[cindex].Memory,
       MRClass[cindex].Nodes,
       (double)MRClass[cindex].Nodes / totalnodes * 100.0,
@@ -1181,10 +1180,10 @@ int UINodeStatShow(
       IAverage,
       MRClass[cindex].Workload / 3600,
       Average);
+    strcat(Buffer,temp_str);
     }  /* END for (cindex) */
 
-  sprintf(Buffer,"%s%8s %5d %7.2f %9d %7.2f %10d %7.2f\n\n",
-    Buffer,
+  sprintf(temp_str,"%8s %5d %7.2f %9d %7.2f %10d %7.2f\n\n",
     "TOTAL",
     totalnodes,
     100.0,
@@ -1192,6 +1191,7 @@ int UINodeStatShow(
     100.0,
     (int)(totalworkload / 3600),
     100.0);
+  strcat(Buffer,temp_str);
 
   strcat(Buffer,"\nNode Statistics\n\n");
 
@@ -1238,16 +1238,16 @@ int UINodeStatShow(
 
           if (mode == 0)
             {
-            sprintf(Buffer,"%s%4dMB Nodes\n",
-              Buffer,
+            sprintf(temp_str,"%4dMB Nodes\n",
               mem);
+            strcat(Buffer,temp_str);
 
-            sprintf(Buffer,"%s%20s %9s %9s %9s\n",
-              Buffer,
+            sprintf(temp_str,"%20s %9s %9s %9s\n",
               "NodeName",
               "Available",
               "Busy",
               "NodeState");
+            strcat(Buffer,temp_str);
             }
           }
 
@@ -1268,23 +1268,23 @@ int UINodeStatShow(
           {
           if (N->SUTime != 0)
             {
-            sprintf(Buffer,"%s%20s %8.2f%s %8.2f%s %9s\n",
-              Buffer,
+            sprintf(temp_str,"%20s %8.2f%s %8.2f%s %9s\n",
               N->Name,
               (double)N->SUTime / N->STTime * 100.0,
               "%",
               (double)N->SATime / N->SUTime * 100.0,
               "%",
               MNodeState[N->State]);
+            strcat(Buffer,temp_str);
             }
           else
             {
-            sprintf(Buffer,"%s%20s %9.2f %9.2f %9s\n",
-              Buffer,
+            sprintf(temp_str,"%20s %9.2f %9.2f %9s\n",
               N->Name,
               0.0,
               0.0,
               MNodeState[N->State]);
+            strcat(Buffer,temp_str);
             }
           }    /* END if (mode == 0) */
         }      /* END if (N->CRes.Mem == mem) */
@@ -1301,8 +1301,7 @@ int UINodeStatShow(
 
     if (MemTotalNodeCount != 0)
       {
-      sprintf(Buffer,"%sSummary:  %3d %4dMB Nodes  %6.2f%s Avail  %6.2f%s Busy  (Current: %6.2f%s Avail  %6.2f%s Busy)\n",
-        Buffer,
+      sprintf(temp_str,"Summary:  %3d %4dMB Nodes  %6.2f%s Avail  %6.2f%s Busy  (Current: %6.2f%s Avail  %6.2f%s Busy)\n",
         MemTotalNodeCount,
         mem,
         (double)MemTotalUpTime / MemTotalTotalTime * 100.0,
@@ -1313,6 +1312,7 @@ int UINodeStatShow(
         "%",
         (double)MemTotalBusyCount / MemTotalNodeCount * 100.0,
         "%");
+      strcat(Buffer,temp_str);
  
       if (mode == 0)
         strcat(Buffer,"\n");
@@ -1323,8 +1323,7 @@ int UINodeStatShow(
 
   if (SystemTotalTotalTime != 0)
     {
-    sprintf(Buffer,"%sSystem Summary:  %3d Nodes  %6.2f%s Avail  %6.2f%s Busy  (Current: %6.2f%s Avail  %6.2f%s Busy)\n",
-      Buffer,
+    sprintf(temp_str,"System Summary:  %3d Nodes  %6.2f%s Avail  %6.2f%s Busy  (Current: %6.2f%s Avail  %6.2f%s Busy)\n",
       SystemTotalNodeCount,
       (double)SystemTotalUpTime / SystemTotalTotalTime * 100.0,
       "%",
@@ -1334,6 +1333,7 @@ int UINodeStatShow(
       "%",
       (double)SystemTotalBusyCount / SystemTotalNodeCount * 100.0,
       "%");
+    strcat(Buffer,temp_str);
     }
 
   strcat(Buffer,"\n");

--- a/src/server/Server.c
+++ b/src/server/Server.c
@@ -473,50 +473,59 @@ int MServerConfigShow(
 
   /* display modules */
 
-  sprintf(Buffer,"%s# SERVER MODULES: ",
-    Buffer);
+  sprintf(temp_str,"# SERVER MODULES: ");
+  strcat(Buffer,temp_str);
 
 #ifdef __MX
-  sprintf(Buffer,"%s MX",
-    Buffer);
+  sprintf(temp_str," MX");
+  strcat(Buffer,temp_str);
 #endif /* __MX */
 
 #ifdef __MMD5
-  sprintf(Buffer,"%s MD5",
-    Buffer);
+  sprintf(temp_str," MD5");
+  strcat(Buffer,temp_str);
 #endif /* __MMD5 */
 
-  sprintf(Buffer,"%s\n",
-    Buffer);
+  sprintf(temp_str,"\n");
+  strcat(Buffer,temp_str);
 
   /* display parameters */
 
-  sprintf(Buffer,"%s%-30s  %s\n",
-    Buffer,
+  sprintf(temp_str,"%-30s  %s\n",
     MParam[pSchedMode],
     MSchedMode[MSched.Mode]); 
+  strcat(Buffer,temp_str);
 
   if ((VFlag || (PIndex == -1) || (PIndex == pServerName)))
     {
-    sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pServerName],MSched.Name);
+    sprintf(temp_str,"%-30s  %s\n",MParam[pServerName],MSched.Name);
+    strcat(Buffer,temp_str);
     }
  
-  sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pServerHost],MSched.ServerHost);
-  sprintf(Buffer,"%s%-30s  %d\n",Buffer,MParam[pServerPort],MSched.ServerPort);
+  sprintf(temp_str,"%-30s  %s\n",MParam[pServerHost],MSched.ServerHost);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %d\n",MParam[pServerPort],MSched.ServerPort);
+  strcat(Buffer,temp_str);
 
   if (MSched.LogFile[0] == '\0')
     {
-    sprintf(Buffer,"%s# NO LOGFILE SPECIFIED\n",Buffer);
-    sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pSchedLogFile],MSched.LogFile);
+    sprintf(temp_str,"# NO LOGFILE SPECIFIED\n");
+    strcat(Buffer,temp_str);
+    sprintf(temp_str,"%-30s  %s\n",MParam[pSchedLogFile],MSched.LogFile);
+    strcat(Buffer,temp_str);
     }
   else
     {
-    sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pSchedLogFile],MSched.LogFile);
-    sprintf(Buffer,"%s%-30s  %d\n",Buffer,MParam[pLogFileMaxSize],MSched.LogFileMaxSize);
-    sprintf(Buffer,"%s%-30s  %d\n",Buffer,MParam[pLogFileRollDepth],MSched.LogFileRollDepth);
+    sprintf(temp_str,"%-30s  %s\n",MParam[pSchedLogFile],MSched.LogFile);
+    strcat(Buffer,temp_str);
+    sprintf(temp_str,"%-30s  %d\n",MParam[pLogFileMaxSize],MSched.LogFileMaxSize);
+    strcat(Buffer,temp_str);
+    sprintf(temp_str,"%-30s  %d\n",MParam[pLogFileRollDepth],MSched.LogFileRollDepth);
+    strcat(Buffer,temp_str);
     }
 
-  sprintf(Buffer,"%s%-30s  %d\n",Buffer,MParam[pLogLevel],mlog.Threshold);
+  sprintf(temp_str,"%-30s  %d\n",MParam[pLogLevel],mlog.Threshold);
+  strcat(Buffer,temp_str);
  
   if ((mlog.FacilityList != fALL) || 
       (VFlag || 
@@ -539,47 +548,68 @@ int MServerConfigShow(
     if (mlog.FacilityList == fALL)
       strcpy(Line,MLogFacilityType[dfALL]);
  
-    sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pLogFacility],Line);
+    sprintf(temp_str,"%-30s  %s\n",MParam[pLogFacility],Line);
+    strcat(Buffer,temp_str);
     }
 
-  sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pMServerHomeDir],MSched.HomeDir);
-  sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pSchedToolsDir],MSched.ToolsDir);
-  sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pSchedLogDir],MSched.LogDir);
-  sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pStatDir],MStat.StatDir);
+  sprintf(temp_str,"%-30s  %s\n",MParam[pMServerHomeDir],MSched.HomeDir);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %s\n",MParam[pSchedToolsDir],MSched.ToolsDir);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %s\n",MParam[pSchedLogDir],MSched.LogDir);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %s\n",MParam[pStatDir],MStat.StatDir);
+  strcat(Buffer,temp_str);
  
-  sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pSchedLockFile],MSched.LockFile);
-  sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pSchedConfigFile],MSched.ConfigFile);
+  sprintf(temp_str,"%-30s  %s\n",MParam[pSchedLockFile],MSched.LockFile);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %s\n",MParam[pSchedConfigFile],MSched.ConfigFile);
+  strcat(Buffer,temp_str);
 
   if ((MSched.Action[mactAdminEvent][0] != '\0') || VFlag)
     { 
-    sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pAdminEAction],MSched.Action[mactAdminEvent]);
+    sprintf(temp_str,"%-30s  %s\n",MParam[pAdminEAction],MSched.Action[mactAdminEvent]);
+    strcat(Buffer,temp_str);
     }
 
   if ((MSched.Action[mactJobFB][0] != '\0') || VFlag)
     {
-    sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[mcoJobFBAction],MSched.Action[mactJobFB]);
+    sprintf(temp_str,"%-30s  %s\n",MParam[mcoJobFBAction],MSched.Action[mactJobFB]);
+    strcat(Buffer,temp_str);
     }
 
   if ((MSched.Action[mactMail][0] != '\0') || VFlag)
     {
-    sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[mcoMailAction],MSched.Action[mactMail]);
+    sprintf(temp_str,"%-30s  %s\n",MParam[mcoMailAction],MSched.Action[mactMail]);
+    strcat(Buffer,temp_str);
     }
  
-  sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pCheckPointFile],MCP.CPFileName);
-  sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pCheckPointInterval],MULToTString(MCP.CPInterval));
-  sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pCheckPointExpirationTime],MULToTString(MCP.CPExpirationTime));
+  sprintf(temp_str,"%-30s  %s\n",MParam[pCheckPointFile],MCP.CPFileName);
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %s\n",MParam[pCheckPointInterval],MULToTString(MCP.CPInterval));
+  strcat(Buffer,temp_str);
+  sprintf(temp_str,"%-30s  %s\n",MParam[pCheckPointExpirationTime],MULToTString(MCP.CPExpirationTime));
+  strcat(Buffer,temp_str);
 
-  if ((MSched.MonitoredJob[0] != '\0') || (VFlag || (PIndex == -1) || (PIndex == pMonitoredJob)))
-    sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pMonitoredJob],MSched.MonitoredJob);
+  if ((MSched.MonitoredJob[0] != '\0') || (VFlag || (PIndex == -1) || (PIndex == pMonitoredJob))){
+    sprintf(temp_str,"%-30s  %s\n",MParam[pMonitoredJob],MSched.MonitoredJob);
+    strcat(Buffer,temp_str);
+  }
  
-  if ((MSched.MonitoredNode[0] != '\0') || (VFlag || (PIndex == -1) || (PIndex == pMonitoredNode)))
-    sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pMonitoredNode],MSched.MonitoredNode);
+  if ((MSched.MonitoredNode[0] != '\0') || (VFlag || (PIndex == -1) || (PIndex == pMonitoredNode))){
+    sprintf(temp_str,"%-30s  %s\n",MParam[pMonitoredNode],MSched.MonitoredNode);
+    strcat(Buffer,temp_str);
+  }
  
-  if ((MSched.MonitoredFunction[0] != '\0') || (VFlag || (PIndex == -1) || (PIndex == pMonitoredFunction)))
-    sprintf(Buffer,"%s%-30s  %s\n",Buffer,MParam[pMonitoredFunction],MSched.MonitoredFunction);
+  if ((MSched.MonitoredFunction[0] != '\0') || (VFlag || (PIndex == -1) || (PIndex == pMonitoredFunction))){
+    sprintf(temp_str,"%-30s  %s\n",MParam[pMonitoredFunction],MSched.MonitoredFunction);
+    strcat(Buffer,temp_str);
+  }
 
-  if ((MSched.ResDepth != DEFAULT_RES_DEPTH) || (VFlag || (PIndex == -1) || (PIndex == pResDepth)))
-    sprintf(Buffer,"%s%-30s  %d\n",Buffer,MParam[pResDepth],MSched.ResDepth);
+  if ((MSched.ResDepth != DEFAULT_RES_DEPTH) || (VFlag || (PIndex == -1) || (PIndex == pResDepth))){
+    sprintf(temp_str,"%-30s  %d\n",MParam[pResDepth],MSched.ResDepth);
+    strcat(Buffer,temp_str);
+  }
 
   strcat(Buffer,"\n");      
 

--- a/src/server/UserI.c
+++ b/src/server/UserI.c
@@ -973,9 +973,9 @@ int UIJobShow(
       if (tindex > 0)
         strcat(Line,",");
  
-      sprintf(Line,"%s %ld",
-        Line,
+      sprintf(temp_str," %ld",
         J->SpecWCLimit[tindex]);
+      strcat(Line,temp_str);
       }  /* END for (tindex) */
  
     MUSNPrintF(&BPtr,&BSpace,"%s",
@@ -1034,9 +1034,9 @@ int UIJobShow(
         if (tindex > 0)
           strcat(Line,",");
  
-        sprintf(Line,"%s %d",
-          Line,
+        sprintf(temp_str," %d",
           RQ->TaskRequestList[tindex]);
+        strcat(Line,temp_str);
         }  /* END for (tindex) */
  
       MUSNPrintF(&BPtr,&BSpace,"%s",
@@ -1868,10 +1868,10 @@ int UIJobShow(
  
         if (Flags & (1 << mcmVerbose))
           {
-          sprintf(MsgBuf,"%s%-24s rejected : %s\n",
-            MsgBuf,
+          sprintf(temp_str,"%-24s rejected : %s\n",
             N->Name,
             MAllocRejType[marState]);
+          strcat(MsgBuf,temp_str);
           }
         }
       else
@@ -1897,10 +1897,10 @@ int UIJobShow(
  
           if (Flags & (1 << mcmVerbose))
             {
-            sprintf(MsgBuf,"%s%-24s accepted : %d tasks supported\n",
-              MsgBuf,
+            sprintf(temp_str,"%-24s accepted : %d tasks supported\n",
               N->Name,
               TasksAllowed);
+            strcat(MsgBuf,temp_str);
             }
           }
         else
@@ -1909,10 +1909,10 @@ int UIJobShow(
  
           if (Flags & (1 << mcmVerbose))
             {
-            sprintf(MsgBuf,"%s%-24s rejected : %s\n",
-              MsgBuf,
+            sprintf(temp_str,"%-24s rejected : %s\n",
               N->Name,
               MAllocRejType[rindex]); 
+            strcat(MsgBuf,temp_str);
             }
           }
         }
@@ -2901,8 +2901,8 @@ int MUIGridCtl(
             {
             MACLClear(SR->ACL,maDuration);
  
-            sprintf(S->SBuffer,"%sMAXTIME set to DEFAULT\n",
-              S->SBuffer);
+            sprintf(temp_str,"MAXTIME set to DEFAULT\n");
+            strcat(S->SBuffer,temp_str);
             }
           else
             {
@@ -2919,9 +2919,9 @@ int MUIGridCtl(
               (1 << maclRequired),
               0);
  
-            sprintf(S->SBuffer,"%sMAXTIME set to %ld\n",
-              S->SBuffer,
+            sprintf(temp_str,"MAXTIME set to %ld\n",
               MaxTime);
+            strcat(S->SBuffer,temp_str);
             }
           }
         else if (!strncmp(ptr,"DAYS=",strlen("DAYS="))) 
@@ -2930,8 +2930,8 @@ int MUIGridCtl(
             {
             SR->Days = 0;
  
-            sprintf(S->SBuffer,"%sDAYS set to DEFAULT\n",
-              S->SBuffer);
+            sprintf(temp_str,"DAYS set to DEFAULT\n");
+            strcat(S->SBuffer,temp_str);
             }
           else
             {
@@ -2949,9 +2949,9 @@ int MUIGridCtl(
                 }
               }   /* END for (vindex) */
  
-            sprintf(S->SBuffer,"%sDAYS set to %s\n",
-              S->SBuffer,
+            sprintf(temp_str,"DAYS set to %s\n",
               ptr + strlen("DAYS="));
+            strcat(S->SBuffer,temp_str);
             }
           }
         else if (!strncmp(ptr,"STARTTIME=",strlen("STARTTIME=")))
@@ -2960,16 +2960,16 @@ int MUIGridCtl(
             {
             SR->StartTime = 0;
  
-            sprintf(S->SBuffer,"%sSTARTTIME set to DEFAULT\n",
-              S->SBuffer);
+            sprintf(temp_str,"STARTTIME set to DEFAULT\n");
+            strcat(S->SBuffer,temp_str);
             }
           else
             {
             SR->StartTime = MUTimeFromString(ptr + strlen("STARTTIME=")); 
  
-            sprintf(S->SBuffer,"%sSTARTTIME set to %s\n",
-              S->SBuffer,
+            sprintf(temp_str,"STARTTIME set to %s\n",
               MULToTString(SR->StartTime));
+            strcat(S->SBuffer,temp_str);
             }
           }
         else if (!strncmp(ptr,"ENDTIME=",strlen("ENDTIME=")))
@@ -2978,16 +2978,16 @@ int MUIGridCtl(
             {
             SR->EndTime = 0;
  
-            sprintf(S->SBuffer,"%sENDTIME set to DEFAULT\n",
-              S->SBuffer);
+            sprintf(temp_str,"ENDTIME set to DEFAULT\n");
+            strcat(S->SBuffer,temp_str);
             }
           else
             {
             SR->EndTime = MUTimeFromString(ptr + strlen("ENDTIME="));
  
-            sprintf(S->SBuffer,"%sENDTIME set to %s\n",
-              S->SBuffer,
+            sprintf(temp_str,"ENDTIME set to %s\n",
               MULToTString(SR->EndTime));
+            strcat(S->SBuffer,temp_str);
             }
           }
         else if (!strncmp(ptr,"TASKCOUNT=",strlen("TASKCOUNT=")))
@@ -2996,16 +2996,16 @@ int MUIGridCtl(
             {
             SR->TaskCount = 0;
  
-            sprintf(S->SBuffer,"%sTASKCOUNT set to DEFAULT\n",
-              S->SBuffer);
+            sprintf(temp_str,"TASKCOUNT set to DEFAULT\n");
+            strcat(S->SBuffer,temp_str);
             }
           else
             {
             SR->TaskCount = atoi(ptr + strlen("TASKCOUNT="));
  
-            sprintf(S->SBuffer,"%sTASKCOUNT set to %d\n",
-              S->SBuffer,
+            sprintf(temp_str,"TASKCOUNT set to %d\n",
               SR->TaskCount);
+            strcat(S->SBuffer,temp_str);
             }
           }
         else if (!strncmp(ptr,"CHARGEACCOUNT=",strlen("CHARGEACCOUNT="))) 
@@ -3039,16 +3039,16 @@ int MUIGridCtl(
             {
             SR->A = NULL;
  
-            sprintf(S->SBuffer,"%sCHARGEACCOUNT set to DEFAULT\n",
-              S->SBuffer);
+            sprintf(temp_str,"CHARGEACCOUNT set to DEFAULT\n");
+            strcat(S->SBuffer,temp_str);
             }
           else
             {
             MAcctAdd(ptr + strlen("CHARGEACCOUNT="),&SR->A);
  
-            sprintf(S->SBuffer,"%sCHARGEACCOUNT set to %s\n",
-              S->SBuffer,
+            sprintf(temp_str,"CHARGEACCOUNT set to %s\n",
               (SR->A != NULL) ? SR->A->Name : NONE);
+            strcat(S->SBuffer,temp_str);
             } 
           }    /* END else if () */
  
@@ -3068,9 +3068,9 @@ int MUIGridCtl(
  
         if (SRes[srindex].R[dindex] != NULL)
           {
-          sprintf(S->SBuffer,"%sINFO:     reservation %s recycled\n",
-            S->SBuffer,
+          sprintf(temp_str,"INFO:     reservation %s recycled\n",
             SRes[srindex].R[dindex]->Name);
+          strcat(S->SBuffer,temp_str);
  
           MResDestroy(&SRes[srindex].R[dindex]);
  
@@ -3443,8 +3443,8 @@ int MUINodeCtl(
         return(FAILURE);
         }
 
-      sprintf(tmpLine,"%ssuccessfully processed node create request\n",
-        tmpLine);
+      sprintf(temp_str,"successfully processed node create request\n");
+      strcat(tmpLine,temp_str);
  
       break;
 
@@ -3460,15 +3460,15 @@ int MUINodeCtl(
 
         if (MNodeRemove(N) == FAILURE)
           {
-          sprintf(tmpLine,"%sERROR:    cannot remove node '%s'\n",
-            tmpLine,
+          sprintf(temp_str,"ERROR:    cannot remove node '%s'\n",
             NodeName);
+          strcat(tmpLine,temp_str);
           }
         else
           {
-          sprintf(tmpLine,"%ssuccessfully removed node '%s'\n",
-            tmpLine,
+          sprintf(temp_str,"successfully removed node '%s'\n",
             NodeName);
+          strcat(tmpLine,temp_str);
           }
         }  /* END for (nindex) */
 
@@ -3490,9 +3490,9 @@ int MUINodeCtl(
 
             if ((aindex = MUGetIndex(ptr,MNodeAttr,FALSE,mnaNONE)) == mnaNONE)
               {
-              sprintf(tmpLine,"%sERROR:    invalid argument received (%s)\n",
-                tmpLine,
+              sprintf(temp_str,"ERROR:    invalid argument received (%s)\n",
                 ptr);
+              strcat(tmpLine,temp_str);
 
               MUISMsgAdd(S,tmpLine);
 
@@ -3507,22 +3507,22 @@ int MUINodeCtl(
 
               if (MNodeSetAttr(N,aindex,(void *)ptr,mdfString,mSet) == FAILURE)
                 {
-                sprintf(tmpLine,"%sERROR:    cannot set attribute '%s' to '%s' on node '%s'\n",
-                  tmpLine,
+                sprintf(temp_str,"ERROR:    cannot set attribute '%s' to '%s' on node '%s'\n",
                   MNodeAttr[aindex],
                   ptr, 
                   N->Name);
+                strcat(tmpLine,temp_str);
 
                 MUISMsgAdd(S,tmpLine);
 
                 return(FAILURE);
                 }
 
-              sprintf(tmpLine,"%sattribute '%s' set to '%s' on node '%s'\n",
-                tmpLine,
+              sprintf(temp_str,"attribute '%s' set to '%s' on node '%s'\n",
                 MNodeAttr[aindex],
                 ptr,
                 N->Name);
+              strcat(tmpLine,temp_str);
               }    /* END for (nindex) */
 
             ptr = MUStrTok(NULL,"=;",&TokPtr);
@@ -3530,9 +3530,9 @@ int MUINodeCtl(
             continue;
             }      /* END if (MSched.Mode == msmSim) */
 
-          sprintf(tmpLine,"%sERROR:    invalid argument received (%s)\n",
-            tmpLine,
+          sprintf(temp_str,"ERROR:    invalid argument received (%s)\n",
             ptr);
+          strcat(tmpLine,temp_str);
 
           MUISMsgAdd(S,tmpLine);
  
@@ -3582,8 +3582,8 @@ int MUINodeCtl(
 
             if ((ResID = MUStrTok(ptr,".",&TokPtr2)) == NULL)
               {
-              sprintf(S->SBuffer,"%sERROR:    no resource ID specified\n",
-                S->SBuffer);
+              sprintf(temp_str,"ERROR:    no resource ID specified\n");
+              strcat(S->SBuffer,temp_str);
  
               return(FAILURE);
               }
@@ -3592,17 +3592,17 @@ int MUINodeCtl(
 
             if ((ptr2 = MUStrTok(NULL,".",&TokPtr2)) == NULL)
               {
-              sprintf(S->SBuffer,"%sERROR:    no subcommand specified\n",
-                S->SBuffer);
+              sprintf(temp_str,"ERROR:    no subcommand specified\n");
+              strcat(S->SBuffer,temp_str);
  
               return(FAILURE);
               }
 
             if ((cindex = MUGetIndex(ptr2,NCModSubC,FALSE,ncmodscNONE)) == ncmodscNONE)
               {
-              sprintf(S->SBuffer,"%sERROR:    invalid modify subcommand specified (%s)\n",
-                S->SBuffer,
+              sprintf(temp_str,"ERROR:    invalid modify subcommand specified (%s)\n",
                 ptr2);
+              strcat(S->SBuffer,temp_str);
  
               return(FAILURE);
               }     
@@ -3634,8 +3634,8 @@ int MUINodeCtl(
                 {
                 /* generic resource overflow */
 
-                sprintf(S->SBuffer,"%sERROR:    generic resource overflow\n",
-                  S->SBuffer);
+                sprintf(temp_str,"ERROR:    generic resource overflow\n");
+                strcat(S->SBuffer,temp_str);
  
                 return(FAILURE);
                 }
@@ -3680,9 +3680,9 @@ int MUINodeCtl(
  
             if ((vindex = MUGetIndex(ptr,MNodeState,FALSE,mnsNONE)) == mnsNONE)
               {
-              sprintf(S->SBuffer,"%sERROR:    invalid node state received (%s)\n",
-                S->SBuffer,
+              sprintf(temp_str,"ERROR:    invalid node state received (%s)\n",
                 ptr);
+              strcat(S->SBuffer,temp_str);
  
               return(FAILURE);
               }
@@ -3775,11 +3775,11 @@ int MUISMsgClear(
  
     Align = (int)strlen(S->SBuffer) + (int)strlen(MCKeyword[mckArgs]);
  
-    sprintf(S->SBuffer,"%s%*s%s",
-      S->SBuffer,
+    sprintf(temp_str,"%*s%s",
       16 - (Align % 16),
       " ",
       MCKeyword[mckArgs]);
+    strcat(S->SBuffer,temp_str);
  
     S->SPtr = &S->SBuffer[strlen(S->SBuffer)];
     }
@@ -4923,10 +4923,10 @@ int UIJobStart(
  
   if (J->State != mjsIdle)
     {
-    sprintf(Buffer,"%sjob '%s' is in state '%s'  (state must be idle)\n",
-      Buffer,
+    sprintf(temp_str,"job '%s' is in state '%s'  (state must be idle)\n",
       J->Name,
       MJobState[J->State]); 
+    strcat(Buffer,temp_str);
  
     return(SUCCESS);
     }
@@ -4935,10 +4935,10 @@ int UIJobStart(
  
   if (J->EState != mjsIdle)
     {
-    sprintf(Buffer,"%sjob '%s' is in expected state '%s' (expected state must be idle)\n",
-      Buffer,
+    sprintf(temp_str,"job '%s' is in expected state '%s' (expected state must be idle)\n",
       J->Name,
       MJobState[J->EState]);
+    strcat(Buffer,temp_str);
  
     return(SUCCESS);
     }
@@ -4949,10 +4949,10 @@ int UIJobStart(
     {
     if (RQ->DRes.Procs * J->Request.TC > MPar[0].ARes.Procs)
       {
-      sprintf(Buffer,"%sjob cannot run  (insufficient idle procs:  %d needed  %d available)\n",
-        Buffer,
+      sprintf(temp_str,"job cannot run  (insufficient idle procs:  %d needed  %d available)\n",
         J->Request.TC * RQ->DRes.Procs,
         MPar[0].ARes.Procs);
+      strcat(Buffer,temp_str);
  
       return(SUCCESS);
       }
@@ -4971,9 +4971,9 @@ int UIJobStart(
           NULL,
           MSched.Time) == FAILURE)
       {
-      sprintf(Buffer,"%sjob cannot run (rejected by policy %s)\n",
-        Buffer,
+      sprintf(temp_str,"job cannot run (rejected by policy %s)\n",
         MPolicyRejection[PReason]); 
+      strcat(Buffer,temp_str);
  
       return(SUCCESS);
       }
@@ -5085,8 +5085,8 @@ int UIJobStart(
  
     if (pindex == MAX_MPAR)
       {
-      sprintf(Buffer,"%sjob cannot run (available nodes do not meet requirements in any partition)\n",
-        Buffer);
+      sprintf(temp_str,"job cannot run (available nodes do not meet requirements in any partition)\n");
+      strcat(Buffer,temp_str);
  
       return(SUCCESS);
       }
@@ -5108,15 +5108,15 @@ int UIJobStart(
 
         /* append domain and try again */
  
-        sprintf(tmpName,"%s%s",
-          tmpName,
+        sprintf(temp_str,"%s",
           MSched.DefaultDomain);
+        strcat(tmpName,temp_str);
  
         if (MNodeFind(tmpName,&N) != SUCCESS)
           {
-          sprintf(Buffer,"%sERROR:  cannot locate node '%s' in specified nodelist\n",
-            Buffer,
+          sprintf(temp_str,"ERROR:  cannot locate node '%s' in specified nodelist\n",
             ptr);
+          strcat(Buffer,temp_str);
  
           return(FAILURE);
           }
@@ -5138,10 +5138,10 @@ int UIJobStart(
  
     if (nodeindex < (int)(RQ->DRes.Procs * J->Request.TC))
       {
-      sprintf(Buffer,"%sERROR:  incorrect number of procs in hostlist. (%d requested  %d specified)\n",
-        Buffer,
+      sprintf(temp_str,"ERROR:  incorrect number of procs in hostlist. (%d requested  %d specified)\n",
         J->Request.TC * RQ->DRes.Procs,
         nodeindex);
+      strcat(Buffer,temp_str);
  
       return(FAILURE);
       }
@@ -5160,9 +5160,9 @@ int UIJobStart(
     DBG(2,fUI) DPrint("INFO:     cannot allocate nodes for job '%s'\n",
       J->Name);
  
-    sprintf(Buffer,"%sERROR:    cannot allocate nodes for job '%s'\n",
-      Buffer,
+    sprintf(temp_str,"ERROR:    cannot allocate nodes for job '%s'\n",
       J->Name);
+    strcat(Buffer,temp_str);
  
     return(SUCCESS);
     }
@@ -5175,11 +5175,11 @@ int UIJobStart(
       J->Name,
       Auth);
  
-    sprintf(Buffer,"%sjob '%s' cannot be started on %d proc%s\n",
-      Buffer, 
+    sprintf(temp_str,"job '%s' cannot be started on %d proc%s\n",
       J->Name,
       PC,
       (PC == 1) ? "" : "s");
+    strcat(Buffer,temp_str);
  
     return(SUCCESS);
     }
@@ -5188,11 +5188,11 @@ int UIJobStart(
     J->Name,
     Auth);
  
-  sprintf(Buffer,"%sjob '%s' started on %d proc%s\n",
-    Buffer,
+  sprintf(temp_str,"job '%s' started on %d proc%s\n",
     J->Name,
     PC,
     (PC == 1) ? "" : "s");
+  strcat(Buffer,temp_str);
  
   if (MSched.Mode == msmNormal)
     {
@@ -6461,8 +6461,8 @@ int UIResCreate(
     {
     DBG(3,fUI) DPrint("WARNING:  cannot create reservation (invalid timeframe)\n");
 
-    sprintf(SBuffer,"%scannot create reservation (invalid timeframe)\n",
-      SBuffer);
+    sprintf(temp_str,"cannot create reservation (invalid timeframe)\n");
+    strcat(SBuffer,temp_str);
 
     return(FAILURE);
     }
@@ -6573,9 +6573,9 @@ int UIResCreate(
           *SBufSize,
           &tmpRQ) == FAILURE)
       {
-      sprintf(SBuffer,"%sERROR:    cannot select requested tasks for '%s'\n",
-        SBuffer,
+      sprintf(temp_str,"ERROR:    cannot select requested tasks for '%s'\n",
         Pattern);
+      strcat(SBuffer,temp_str);
 
       return(FAILURE);
       }
@@ -6594,9 +6594,9 @@ int UIResCreate(
           &NodeCount,
           SBuffer) == FAILURE)
       {
-      sprintf(SBuffer,"%sERROR:    cannot determine nodelist for '%s'\n",
-        SBuffer,
+      sprintf(temp_str,"ERROR:    cannot determine nodelist for '%s'\n",
         Pattern);
+      strcat(SBuffer,temp_str);
 
       return(FAILURE);
       }
@@ -6885,17 +6885,17 @@ int UIResCreate(
           ResPLevel,
           &tmpTime) == FAILURE)
       {
-      sprintf(SBuffer,"%sERROR:    limits prevent reservation creation\n",
-        SBuffer);
+      sprintf(temp_str,"ERROR:    limits prevent reservation creation\n");
+      strcat(SBuffer,temp_str);
 
       return(FAILURE);
       }
 
     if (tmpTime != StartTime)
       {
-      sprintf(SBuffer,"%sERROR:    cannot reserve requested resources until %s\n",
-        SBuffer,
+      sprintf(temp_str,"ERROR:    cannot reserve requested resources until %s\n",
         MULToTString(tmpTime - MSched.Time));
+      strcat(SBuffer,temp_str);
 
       return(FAILURE);
       }
@@ -6935,11 +6935,11 @@ int UIResCreate(
       NodeCount,
       (NodeCount == 1) ? "" : "s");
 
-    sprintf(SBuffer,"%scannot create reservation for '%s' on %d node%s\n",
-      SBuffer,
+    sprintf(temp_str,"cannot create reservation for '%s' on %d node%s\n",
       Name,
       NodeCount,
       (NodeCount == 1) ? "" : "s");
+    strcat(SBuffer,temp_str);
 
     return(FAILURE);
     }  /* END if (MResCreate() == FAILURE) */
@@ -6987,10 +6987,10 @@ int UIResCreate(
 
   for (nindex = 0;nindex < NodeCount;nindex++)
     {
-    sprintf(SBuffer,"%s%s:%d\n",
-      SBuffer,
+    sprintf(temp_str,"%s:%d\n",
       NodeList[nindex].N->Name,
       NodeList[nindex].TC);
+    strcat(SBuffer,temp_str);
     }  /* END for (nindex) */
 
   sprintf(Message,"RESERVATIONCREATION:  %s USER %s %ld %ld %d %d\n",
@@ -7371,10 +7371,10 @@ int __MUIJobToXML(
       {
       N = J->NodeList[nindex].N;
 
-      sprintf(tmpLine,"%s%d:%d;",
-        tmpLine,
+      sprintf(temp_str,"%d:%d;",
         N->FrameIndex,
         N->SlotIndex);
+      strcat(tmpLine,temp_str);
 
       DBG(4,fUI) DPrint("INFO:     adding node '%s' of job '%s' to buffer\n",
         N->Name,
@@ -7891,8 +7891,8 @@ int MUIJobDiagnose(
 
   Truncated = FALSE;
 
-  sprintf(Buffer,"%sDiagnosing Jobs\n",
-    Buffer);
+  sprintf(temp_str,"Diagnosing Jobs\n");
+  strcat(Buffer,temp_str);
 
   /* FORMAT:       NAME STATE PARTI PROCS QOS WCLI RESER MPR USR GRP ACC QTIM NET OPS ARC MEM DSK CLAS FEAT */
 
@@ -7972,8 +7972,7 @@ int MUIJobDiagnose(
           }
         }
 
-      sprintf(Buffer,"%s%-18s %8.8s %3.3s %4d %3.3s %11s %1d %4d %8.8s %8.8s %8.8s %11s %8s %6s %6s %6s %6s %6s %11s ",
-        Buffer,
+      sprintf(temp_str,"%-18s %8.8s %3.3s %4d %3.3s %11s %1d %4d %8.8s %8.8s %8.8s %11s %8s %6s %6s %6s %6s %6s %11s ",
         J->Name,
         MJobState[J->State],
         MAList[ePartition][RQ->PtIndex],
@@ -7993,10 +7992,11 @@ int MUIJobDiagnose(
         DiskLine,
         ProcLine,
         ClassLine);
+      strcat(Buffer,temp_str);
 
-      sprintf(Buffer,"%s%s\n",
-        Buffer,
+      sprintf(temp_str,"%s\n",
         MUMAList(eFeature,RQ->ReqFBM,sizeof(RQ->ReqFBM)));
+      strcat(Buffer,temp_str);
       }  /* END if (Truncated == FALSE) */
 
     TotalJobCount++;
@@ -8014,11 +8014,11 @@ int MUIJobDiagnose(
         {
         if (Truncated == FALSE)
           {
-          sprintf(Buffer,"%sWARNING:  job '%s' utilizes more procs than dedicated (%.2lf > %d)\n",
-            Buffer,
+          sprintf(temp_str,"WARNING:  job '%s' utilizes more procs than dedicated (%.2lf > %d)\n",
             J->Name,
             RQ->URes.Procs / 100.0,
             RQ->DRes.Procs);
+          strcat(Buffer,temp_str);
           }
         }
 
@@ -8026,11 +8026,11 @@ int MUIJobDiagnose(
         {
         if (Truncated == FALSE)
           {
-          sprintf(Buffer,"%sWARNING:  job '%s' utilizes more memory than dedicated (%d > %d)\n",
-            Buffer,
+          sprintf(temp_str,"WARNING:  job '%s' utilizes more memory than dedicated (%d > %d)\n",
             J->Name,
             RQ->URes.Mem,
             RQ->DRes.Mem);
+          strcat(Buffer,temp_str);
           }
         }
 
@@ -8041,11 +8041,11 @@ int MUIJobDiagnose(
         if (Truncated == FALSE)
           {
 /*
-          sprintf(Buffer,"%sWARNING:  job '%s' unsynchronized proc usage stats (RM: %ld  Sample: %ld)\n",
-            Buffer,
+          sprintf(temp_str,"WARNING:  job '%s' unsynchronized proc usage stats (RM: %ld  Sample: %ld)\n",
             J->Name,
             (long)RQ->LURes.Procs,
             (long)J->PSUtilized);
+          strcat(Buffer,temp_str);
  */
           }
         }
@@ -8055,13 +8055,13 @@ int MUIJobDiagnose(
         if (Truncated == FALSE)
           {
 /*
-          sprintf(Buffer,"%sWARNING:  job '%s' walltime tracking is corrupt (W:%ld + S:%ld) != (P:%ld - S:%ld)\n",
-            Buffer,
+          sprintf(temp_str,"WARNING:  job '%s' walltime tracking is corrupt (W:%ld + S:%ld) != (P:%ld - S:%ld)\n",
             J->Name,
             J->AWallTime,
             J->SWallTime,
             MSched.Time,
             J->StartTime);
+          strcat(Buffer,temp_str);
  */
           }
         }
@@ -8076,11 +8076,11 @@ int MUIJobDiagnose(
         {
         if ((J->State != mjsRunning) || (J->EState != mjsStarting))
           {
-          sprintf(Buffer,"%sWARNING:  job '%s' state '%s' does not match expected state '%s'\n",
-            Buffer,
+          sprintf(temp_str,"WARNING:  job '%s' state '%s' does not match expected state '%s'\n",
             J->Name,
             MJobState[J->State],
             MJobState[J->EState]);
+          strcat(Buffer,temp_str);
           }
         }
       }
@@ -8091,9 +8091,9 @@ int MUIJobDiagnose(
       {
       if (Truncated == FALSE)
         {
-        sprintf(Buffer,"%sWARNING:  job '%s' has invalid pmask\n",
-          Buffer,
+        sprintf(temp_str,"WARNING:  job '%s' has invalid pmask\n",
           J->Name);
+        strcat(Buffer,temp_str);
         }
       }
 
@@ -8109,9 +8109,9 @@ int MUIJobDiagnose(
         {
         if (Truncated == FALSE)
           {
-          sprintf(Buffer,"%sWARNING:  active job '%s' has no reservation\n",
-            Buffer,
+          sprintf(temp_str,"WARNING:  active job '%s' has no reservation\n",
             J->Name);
+          strcat(Buffer,temp_str);
           }
         }
 
@@ -8127,9 +8127,9 @@ int MUIJobDiagnose(
         {
         if (Truncated == FALSE)
           {
-          sprintf(Buffer,"%sWARNING:  active job '%s' is not in MAQ table\n",
-            Buffer,
+          sprintf(temp_str,"WARNING:  active job '%s' is not in MAQ table\n",
             J->Name);
+          strcat(Buffer,temp_str);
           }
         }
 
@@ -8141,11 +8141,11 @@ int MUIJobDiagnose(
           {
           strcpy(WCLimit,MULToTString(J->WCLimit));
 
-          sprintf(Buffer,"%sWARNING:  job '%s' has exceeded wallclock limit (%s > %s) \n",
-            Buffer,
+          sprintf(temp_str,"WARNING:  job '%s' has exceeded wallclock limit (%s > %s) \n",
             J->Name,
             MULToTString(MSched.Time - J->StartTime),
             WCLimit);
+          strcat(Buffer,temp_str);
           }
         }    /* END if MSched.Time */
       }      /* END if J->State    */
@@ -8157,10 +8157,10 @@ int MUIJobDiagnose(
         {
         if (Truncated == FALSE)
           {
-          sprintf(Buffer,"%sWARNING:  job '%s' has failed to start %d times\n",
-            Buffer,
+          sprintf(temp_str,"WARNING:  job '%s' has failed to start %d times\n",
             J->Name,
             J->StartCount);
+          strcat(Buffer,temp_str);
           }
         }    /* END if J->StartCount */
       }      /* END else if J->State */
@@ -8201,9 +8201,9 @@ int MUIJobDiagnose(
 
     if ((Truncated == FALSE) && (Flags & (1 << mcmVerbose)))
       {
-      sprintf(Buffer,"%s\n\nMAQ table (%d job slots)\n",
-        Buffer,
+      sprintf(temp_str,"\n\nMAQ table (%d job slots)\n",
         MSched.M[mxoJob]);
+      strcat(Buffer,temp_str);
       }
 
     RunListCount = 0;
@@ -8225,11 +8225,11 @@ int MUIJobDiagnose(
 
       if ((Truncated == FALSE) && (Flags & (1 << mcmVerbose)))
         {
-        sprintf(Buffer,"%sMAQ[%02d] --> Job[%03d] '%s'\n",
-          Buffer,
+        sprintf(temp_str,"MAQ[%02d] --> Job[%03d] '%s'\n",
           jindex,
           MAQ[jindex],
           J->Name);
+        strcat(Buffer,temp_str);
         }
 
       /* verify node consistency */
@@ -8265,13 +8265,13 @@ int MUIJobDiagnose(
             {
             if (Truncated == FALSE)
               {
-              sprintf(Buffer,"%sWARNING:  job '%s' with partition mask %s has node %s allocated from partition %s\n",
-                Buffer,
+              sprintf(temp_str,"WARNING:  job '%s' with partition mask %s has node %s allocated from partition %s\n",
                 J->Name,
                 (J->PAL[0] == 0) ?
                   ALL : MUListAttrs(ePartition,J->PAL[0]),
                 N->Name,
                 MAList[ePartition][N->PtIndex]);
+              strcat(Buffer,temp_str);
               }
             }
 
@@ -8283,12 +8283,12 @@ int MUIJobDiagnose(
             {
             if (Truncated == FALSE)
               {
-              sprintf(Buffer,"%sWARNING:  active job '%s' has inactive node %s allocated for %s (node state: '%s')\n",
-                Buffer,
+              sprintf(temp_str,"WARNING:  active job '%s' has inactive node %s allocated for %s (node state: '%s')\n",
                 J->Name,
                 N->Name,
                 MULToTString(MSched.Time - J->StartTime),
                 MAList[eNodeState][N->State]);
+              strcat(Buffer,temp_str);
               }
             }    /* END if N->State != mnsBusy) */
           }      /* END for (nindex)            */
@@ -8300,11 +8300,11 @@ int MUIJobDiagnose(
         {
         if (Truncated == FALSE)
           {
-          sprintf(Buffer,"%sWARNING:  active job '%s' has inconsistent node allocation  (nodes: %d  nodelist size: %d)\n",
-            Buffer,
+          sprintf(temp_str,"WARNING:  active job '%s' has inconsistent node allocation  (nodes: %d  nodelist size: %d)\n",
             J->Name,
             J->NodeCount,
             NodeCount);
+          strcat(Buffer,temp_str);
           }
         }
 
@@ -8312,36 +8312,36 @@ int MUIJobDiagnose(
         {
         if (Truncated == FALSE)
           {
-          sprintf(Buffer,"%sWARNING:  active job %s has inconsistent proc allocation  (procs: %d  nodelist procs: %d)\n",
-            Buffer,
+          sprintf(temp_str,"WARNING:  active job %s has inconsistent proc allocation  (procs: %d  nodelist procs: %d)\n",
             J->Name,
             MJobGetProcCount(J),
             pcount);
+          strcat(Buffer,temp_str);
           }
         }
 
       RunListCount++;
       }  /* END for (jindex) */
 
-    sprintf(Buffer,"%s\n\nTotal Jobs: %d  Active Jobs: %d\n",
-      Buffer,
+    sprintf(temp_str,"\n\nTotal Jobs: %d  Active Jobs: %d\n",
       TotalJobCount,
       ActiveJobCount);
+    strcat(Buffer,temp_str);
 
     if (TotalJobCount != LinkJobCount)
       {
-      sprintf(Buffer,"%sWARNING:  job table is corrupt (total jobs (%d) != linked jobs (%d))\n",
-        Buffer,
+      sprintf(temp_str,"WARNING:  job table is corrupt (total jobs (%d) != linked jobs (%d))\n",
         TotalJobCount,
         LinkJobCount);
+      strcat(Buffer,temp_str);
       }
 
     if (ActiveJobCount != RunListCount)
       {
-      sprintf(Buffer,"%sWARNING:  active job table is corrupt (active jobs (%d) != active queue size (%d))\n",
-        Buffer,
+      sprintf(temp_str,"WARNING:  active job table is corrupt (active jobs (%d) != active queue size (%d))\n",
         ActiveJobCount,
         RunListCount);
+      strcat(Buffer,temp_str);
       }
 
     /* verify reservations ??? */
@@ -9446,17 +9446,17 @@ int ConfigShow(
 
   ptr[0] = '\0';
 
-  sprintf(ptr,"%s# %s version %s (PID: %d)\n",
-    ptr,
+  sprintf(temp_str,"# %s version %s (PID: %d)\n",
     MSCHED_NAME,
     MSCHED_VERSION,
     MOSGetPID()
     );
+  strcat(ptr,temp_str);
 
   if (MSched.CrashMode == TRUE)
     {
-    sprintf(ptr,"%s# CRASHMODE initiated\n\n",
-      ptr);
+    sprintf(temp_str,"# CRASHMODE initiated\n\n");
+    strcat(ptr,temp_str);
     }
 
   /* policies */
@@ -9686,9 +9686,9 @@ int UIResDestroy(
       DBG(3,fUI) DPrint("ALERT:    cannot locate reservation '%s'\n",
         RID);
 
-      sprintf(Buffer,"%sERROR:    cannot locate reservation '%s'\n",
-        Buffer,
+      sprintf(temp_str,"ERROR:    cannot locate reservation '%s'\n",
         RID);
+      strcat(Buffer,temp_str);
 
       continue;
       }
@@ -9724,10 +9724,10 @@ int UIResDestroy(
         Auth,
         RID);
 
-      sprintf(Buffer,"%sERROR:     user %s is not authorized to release reservation '%s'\n",
-        Buffer,
+      sprintf(temp_str,"ERROR:     user %s is not authorized to release reservation '%s'\n",
         Auth,
         RID);
+      strcat(Buffer,temp_str);
 
       continue;
       }
@@ -9740,10 +9740,10 @@ int UIResDestroy(
       MResType[rtype],
       RID);
 
-    sprintf(Buffer,"%sreleased %s reservation '%s'\n",
-      Buffer,
+    sprintf(temp_str,"released %s reservation '%s'\n",
       MResType[rtype],
       RID);
+    strcat(Buffer,temp_str);
 
     if (MSched.Mode != msmSim)
       {
@@ -10197,8 +10197,8 @@ int UIResDiagnose(
   DBG(4,fUI) DPrint("INFO:     diagnosing reservation table (%d slots)\n",
     MAX_MRES);
 
-  sprintf(SBuffer,"%sDiagnosing Reservations\n",
-    SBuffer);
+  sprintf(temp_str,"Diagnosing Reservations\n");
+  strcat(SBuffer,temp_str);
 
   MResShowState(NULL,Flags,SBuffer,*SBufSize,mAdd);
 
@@ -10298,23 +10298,22 @@ int UIResDiagnose(
 
   if (!strcmp(DiagOpt,NONE))
     {
-    sprintf(SBuffer,"%s\nActive Reserved Processors: %d\n",
-      SBuffer,
+    sprintf(temp_str,"\nActive Reserved Processors: %d\n",
       TotalResAPC);
+    strcat(SBuffer,temp_str);
 
     if ((TotalResAPC + TotalResStatePC) != MPar[0].DRes.Procs)
       {
-      sprintf(SBuffer,"%sWARNING:  reservation table is corrupt:  active procs reserved does not equal active procs detected (%d != %d)\n",
-        SBuffer,
+      sprintf(temp_str,"WARNING:  reservation table is corrupt:  active procs reserved does not equal active procs detected (%d != %d)\n",
         TotalResAPC + TotalResStatePC,
         MPar[0].DRes.Procs);
       }
 
     if (ResLast > ResEnd)
       {
-      sprintf(SBuffer,"%sWARNING:  reservation table is corrupt:  empty slot detected (slot: %d) before end of table\n",
-        SBuffer,
+      sprintf(temp_str,"WARNING:  reservation table is corrupt:  empty slot detected (slot: %d) before end of table\n",
         ResEnd);
+      strcat(SBuffer,temp_str);
       }
 
     MResDiagGrid(SBuffer,(int)*SBufSize,0);

--- a/src/server/mclient.c
+++ b/src/server/mclient.c
@@ -1563,16 +1563,17 @@ int MCClusterShow(
  
       if (S->Failures & (1 << probMemory))
         {
-        sprintf(Warnings,"%scheck memory on node %s\n",
-          Warnings,
+        sprintf(temp_str,"check memory on node %s\n",
           S->NetName[mnetEN0]);
+        strcat(Warnings,temp_str);
         }
  
       if (S->Failures & (1 << probLocalDisk))
         {
-        sprintf(Warnings,"%scheck local disk on node %s\n",
+        sprintf(temp_str,"%scheck local disk on node %s\n",
           Warnings,
           S->NetName[mnetEN0]);
+        strcat(Warnings,temp_str);
         }
  
       if ((S->State == mnsIdle) ||
@@ -1583,18 +1584,18 @@ int MCClusterShow(
  
         if (S->Failures & (1 << probEthernet))
           {
-          sprintf(Warnings,"%scheck ethernet on node %s\n",
-            Warnings,
+          sprintf(temp_str,"check ethernet on node %s\n",
             S->NetName[mnetEN0]);
+          strcat(Warnings,temp_str);
           }
  
         /* report missing HPS_IP adapter */
  
         if (S->Failures & (1 << probHPS_IP))
           {
-          sprintf(Warnings,"%scheck HPS_IP on node %s\n",
-            Warnings,
+          sprintf(temp_str,"check HPS_IP on node %s\n",
             S->NetName[mnetEN0]);
+          strcat(Warnings,temp_str);
           }
         } 
  
@@ -1603,9 +1604,9 @@ int MCClusterShow(
       if ((S->Failures & (1 << probHPS_User)) &&
          (S->State == mnsIdle))
         {
-        sprintf(Warnings,"%scheck HPS_USER on node %s (node is idle)\n",
-          Warnings,
+        sprintf(temp_str,"check HPS_USER on node %s (node is idle)\n",
           S->NetName[mnetEN0]);
+        strcat(Warnings,temp_str);
         }
  
       /* if node is associated with a job */
@@ -1626,10 +1627,10 @@ int MCClusterShow(
  
             SChar = '*';
  
-            sprintf(Warnings,"%sjob %s requires node %s (node is down)\n",
-              Warnings,
+            sprintf(temp_str,"job %s requires node %s (node is down)\n",
               JName[mapj[findex][sindex]],
               S->NetName[mnetEN0]);
+            strcat(Warnings,temp_str);
  
             break;
  
@@ -1639,11 +1640,11 @@ int MCClusterShow(
  
             SChar = JID[mapj[findex][sindex] % MAX_MJOBINDEX]; 
  
-            sprintf(Warnings,"%sjob %s has allocated node %s (node is in state %s)\n",
-              Warnings,
+            sprintf(temp_str,"job %s has allocated node %s (node is in state %s)\n",
               JName[mapj[findex][sindex]],
               S->NetName[mnetEN0],
               MNodeState[System[findex][sindex].State]);
+            strcat(Warnings,temp_str);
  
             break;
  
@@ -1668,9 +1669,9 @@ int MCClusterShow(
  
             SChar = '#';
  
-            sprintf(Warnings,"%snode %s is down\n",
-              Warnings,
+            sprintf(temp_str,"node %s is down\n",
               S->NetName[mnetEN0]);
+            strcat(Warnings,temp_str);
  
             break;
  
@@ -1686,9 +1687,9 @@ int MCClusterShow(
           case mnsIdle:
  
             if (S->Failures & probLocalDisk)
-              sprintf(Warnings,"%snode %s is idle and local disk space is low\n",
-                Warnings,
+              sprintf(temp_str,"node %s is idle and local disk space is low\n",
                 S->NetName[mnetEN0]);
+            strcat(Warnings,temp_str);
  
             SChar = ' ';
  
@@ -1704,9 +1705,9 @@ int MCClusterShow(
  
             SChar = '@';
  
-            sprintf(Warnings,"%snode %s has no job scheduled (node is busy)\n",
-              Warnings,
+            sprintf(temp_str,"node %s has no job scheduled (node is busy)\n",
               S->NetName[mnetEN0]);
+            strcat(Warnings,temp_str);
  
             break;
  
@@ -1722,12 +1723,12 @@ int MCClusterShow(
 
             if (S->SlotsUsed > 0)
               { 
-              sprintf(Warnings,"%snode[%d,%d] %s has unexpected state '%s'\n",
-                Warnings,
+              sprintf(temp_str,"node[%d,%d] %s has unexpected state '%s'\n",
                 findex,
                 sindex,
                 S->NetName[mnetEN0],  
                 MNodeState[S->State]);
+              strcat(Warnings,temp_str);
               }
  
             break;

--- a/src/server/omclient.c
+++ b/src/server/omclient.c
@@ -3816,9 +3816,9 @@ int MCShowSchedulerStatistics(
 
       TimeString[strlen(TimeString) - 1] = '\0';
 
-      sprintf(TimeString,"%s (%ld)\n",
-        TimeString,
+      sprintf(temp_str," (%ld)\n",
         Time);
+      strcat(TimeString,temp_str);
 
       fprintf(stdout,"%s",
         TimeString);


### PR DESCRIPTION
Creates a global variable called temp_str in "moab.h".
Uses sprintf() to format a string and writes it into temp_str,
and uses strcat to append it to the original string buffer.

Fixes issue #1 
