### PR TITLE
Fixes the "incompatible pointer type" warnings

### DIFF
--- a/include/moab.h
+++ b/include/moab.h
@@ -1120,7 +1120,7 @@ typedef struct {
   int (*JobStart)(mjob_t *, mrm_t *, char *, int *);
   int (*JobSubmit)(char *,mrm_t *,mjob_t **,char *,char *,int *);
   int (*JobSuspend)(mjob_t *,mrm_t *,char *,int *);
-  int (*QueueQuery)(mrm_t *, int *, int *);
+  int (*QueueQuery)(mrm_t *, int *, char *, int *);
   int (*ResourceModify)();
   int (*ResourceQuery)(mnode_t *,mrm_t *,char *,int *);
   int (*RMEventQuery)(mrm_t *,int *);

--- a/src/mcom/MS3I.c
+++ b/src/mcom/MS3I.c
@@ -54,17 +54,17 @@ typedef struct {
 int MS3Initialize(mrm_t *,int *);
 int MS3Ping(mrm_t *,enum MStatusCodeEnum *);
 int MS3GetData(mrm_t *,mbool_t,int *);
-int MS3JobStart(mjob_t *,mrm_t *,char *,enum MStatusCodeEnum *);
+int MS3JobStart(mjob_t *,mrm_t *,char *,int *);
 int MS3JobRequeue(mjob_t *,mrm_t *,mjob_t **,char *,int *); 
 int MS3JobModify(mjob_t *,mrm_t *,char *,char *,char *,int *);
-int MS3JobCancel(mjob_t *,mrm_t *,char *,char *,enum MStatusCodeEnum *); 
+int MS3JobCancel(mjob_t *,mrm_t *,char *,char *,int *);
 int MS3JobSubmit(char *,mrm_t *,mjob_t **,long,char *,char *,enum MStatusCodeEnum *);
 int MS3JobSuspend(mjob_t *,mrm_t *,char *,int *); 
 int MS3JobResume(mjob_t *,mrm_t *,char *,int *); 
 int MS3JobCheckpoint(mjob_t *,mrm_t *,mbool_t,char *,int *);
-int MS3ClusterQuery(mrm_t *,int *,char *,enum MStatusCodeEnum *);
-int MS3WorkloadQuery(mrm_t *,int *,enum MStatusCodeEnum *);
-int MS3QueueQuery(mrm_t *,int *,char *,enum MStatusCodeEnum *);
+int MS3ClusterQuery(mrm_t *,int *,char *,int *);
+int MS3WorkloadQuery(mrm_t *,int *,int *);
+int MS3QueueQuery(mrm_t *,int *,char *,int *);
 int MS3JobLoad(char *,void *,mjob_t **,short *,mrm_t *);
 int MS3JobUpdate(void *,mjob_t **,short *,mrm_t *);
 int MS3NodeLoad(mnode_t *,void *,int,mrm_t *);
@@ -1134,7 +1134,7 @@ int MS3QueueQuery(
   mrm_t                *R,      /* I */
   int                  *QCount, /* O */
   char                 *EMsg,   /* O (optional,minsize=MMAX_LINE) */
-  enum MStatusCodeEnum *SC)     /* O (optional) */
+  int                  *SC)     /* O (optional) */
 
   {
   mclass_t *C;
@@ -1342,7 +1342,7 @@ int MS3WorkloadQuery(
 
   mrm_t                *R,       /* I */
   int                  *WCount,  /* O (optional) */
-  enum MStatusCodeEnum *SC)      /* O (optional) */
+  int                  *SC)      /* O (optional) */
 
   {
   mjob_t *J;
@@ -2281,7 +2281,7 @@ int MS3ClusterQuery(
   mrm_t                *R,      /* I */
   int                  *RCount, /* O */
   char                 *EMsg,   /* O (optional,minsize=MMAX_LINE) */
-  enum MStatusCodeEnum *SC)     /* I */
+  int 				   *SC)     /* I */
  
   {
   char  NodeName[MMAX_NAME];
@@ -2632,7 +2632,7 @@ int MS3JobStart(
   mjob_t               *J,   /* I */
   mrm_t                *R,   /* I */
   char                 *Msg, /* O (optional,minsize=MMAX_LINE) */
-  enum MStatusCodeEnum *SC)  /* O (optional) */
+  int                  *SC)  /* O (optional) */
 
   {
   char        *Response = NULL;
@@ -2859,7 +2859,7 @@ int MS3JobCancel(
   mrm_t                *R,        /* I */
   char                 *Message,  /* I */
   char                 *EMsg,     /* O (optional,minsize=MMAX_LINE) */
-  enum MStatusCodeEnum *SC)       /* O (optional) */
+  int                  *SC)       /* O (optional) */
 
   {
   mxml_t *E  = NULL;

--- a/src/moab/MPBSI.c
+++ b/src/moab/MPBSI.c
@@ -105,7 +105,7 @@ int __MPBSGetTaskList(mjob_t *,char *,short *,int);
 int __MPBSNLToTaskString(mnalloc_t *,mrm_t *,char *,int);
 int __MPBSIGetSSSStatus(mnode_t *,char *); 
 long MPBSGetResKVal(char *);
-int MPBSQueueQuery(mrm_t *,int *,int *);
+int MPBSQueueQuery(mrm_t *,int *,char *, int *);
 int __MPBSJobChkExecutable(struct batch_status *);
 
 
@@ -1253,6 +1253,7 @@ int MPBSQueueQuery(
 
   mrm_t *R,
   int   *QCount,
+  char  *EMsg,
   int   *SC)
 
   {

--- a/src/moab/MRMSI.c
+++ b/src/moab/MRMSI.c
@@ -376,6 +376,7 @@ int MRMSQueueQuery(
 
   mrm_t *R,
   int   *QCount,
+  char  *EMsg,
   int   *SC)
  
   {


### PR DESCRIPTION
Changes "enum MStatusCodeEnum *" to "int *" for the corresponding functions' parameter in file MS3I.c
Adds an additional char pointer parameter to MPBSQueueQuery() in file MPBSI.c and MRMSQueueQuery() in file MRMSI.c
