### PR TITLE
fix for unknown type name 'bool'

### DIFF
--- a/src/MPBSI.c
+++ b/src/MPBSI.c
@@ -49,6 +49,7 @@ extern const char *MNodeState[];
 
 #ifdef __MPBS
 
+#include <stdbool.h>
 #include <pbs_error.h>
 #include <pbs_ifl.h>
 


### PR DESCRIPTION
```In file included from MPBSI.c:53:0:
/usr/include/torque/pbs_ifl.h:658:35: error: unknown type name 'bool'
 int pbs_connect_ext(char *server, bool silence);